### PR TITLE
Batch rapid-fire messages within debounce window before dispatching

### DIFF
--- a/src/pochi/config.py
+++ b/src/pochi/config.py
@@ -92,6 +92,7 @@ class WorkspaceConfig:
     folders: dict[str, FolderConfig] = field(default_factory=dict)
     ralph: RalphConfig = field(default_factory=RalphConfig)
     default_engine: str = "claude"
+    message_batch_window_ms: float = 200.0
 
     # Transport configs
     telegram: TelegramConfig | None = None
@@ -168,6 +169,7 @@ def _settings_to_config(settings: WorkspaceSettings, root: Path) -> WorkspaceCon
         folders=folders,
         ralph=ralph,
         default_engine=settings.default_engine,
+        message_batch_window_ms=settings.message_batch_window_ms,
         telegram=telegram,
         telegram_group_id=telegram_group_id,
         bot_token=bot_token,
@@ -209,6 +211,8 @@ def save_workspace_config(config: WorkspaceConfig) -> None:
     workspace.add("name", config.name)
     if config.default_engine != "claude":
         workspace.add("default_engine", config.default_engine)
+    if config.message_batch_window_ms != 200.0:
+        workspace.add("message_batch_window_ms", config.message_batch_window_ms)
     doc.add("workspace", workspace)
 
     # [telegram] section (new format)

--- a/src/pochi/settings.py
+++ b/src/pochi/settings.py
@@ -76,6 +76,7 @@ class WorkspaceSettings(BaseSettings):
     # Core workspace settings
     name: str = ""
     default_engine: str = "claude"
+    message_batch_window_ms: float = 200.0
 
     # Transport config
     telegram: TelegramSettings | None = None
@@ -208,6 +209,7 @@ def load_settings(workspace_root: Path | None = None) -> WorkspaceSettings | Non
         settings = WorkspaceSettings(
             name=workspace_data.get("name", workspace_root.name),
             default_engine=workspace_data.get("default_engine", "claude"),
+            message_batch_window_ms=workspace_data.get("message_batch_window_ms", 200.0),
             telegram=_parse_telegram(data),
             folders=_parse_folders(data),
             ralph=_parse_ralph(data),

--- a/src/pochi/settings.py
+++ b/src/pochi/settings.py
@@ -209,7 +209,9 @@ def load_settings(workspace_root: Path | None = None) -> WorkspaceSettings | Non
         settings = WorkspaceSettings(
             name=workspace_data.get("name", workspace_root.name),
             default_engine=workspace_data.get("default_engine", "claude"),
-            message_batch_window_ms=workspace_data.get("message_batch_window_ms", 200.0),
+            message_batch_window_ms=workspace_data.get(
+                "message_batch_window_ms", 200.0
+            ),
             telegram=_parse_telegram(data),
             folders=_parse_folders(data),
             ralph=_parse_ralph(data),

--- a/src/pochi/workspace/bridge.py
+++ b/src/pochi/workspace/bridge.py
@@ -912,9 +912,7 @@ async def run_workspace_loop(
 
                 # Resolve resume token from the first message's reply
                 r = batch.first_reply_to or {}
-                resume_token = cfg.router.resolve_resume(
-                    processed_text, r.get("text")
-                )
+                resume_token = cfg.router.resolve_resume(processed_text, r.get("text"))
 
                 # Check if replying to a running task
                 reply_id = r.get("message_id")
@@ -937,7 +935,9 @@ async def run_workspace_loop(
                 # Inject orchestrator context for new General topic messages
                 job_text = processed_text
                 if route.is_general and resume_token is None:
-                    job_text = prepend_orchestrator_context(cfg.workspace, processed_text)
+                    job_text = prepend_orchestrator_context(
+                        cfg.workspace, processed_text
+                    )
 
                 # Start the job
                 tg.start_soon(

--- a/src/pochi/workspace/bridge.py
+++ b/src/pochi/workspace/bridge.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import time
 from collections.abc import AsyncIterator, Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import partial
 from pathlib import Path
 from typing import Any
@@ -81,6 +81,197 @@ def _parse_topic_resume_key(key: str) -> tuple[int | None, str]:
         return None, key[8:]
     # Fallback - treat as general topic
     return None, key
+
+
+@dataclass
+class PendingMessage:
+    """A message waiting in the debounce queue."""
+
+    message_id: int
+    text: str
+    timestamp: float
+    reply_to: dict[str, Any] | None
+    raw_message: dict[str, Any]
+
+
+@dataclass
+class MessageBatch:
+    """Combined messages ready for dispatch."""
+
+    message_ids: list[int]
+    combined_text: str
+    first_reply_to: dict[str, Any] | None
+    last_message_id: int
+    topic_id: int | None
+    raw_messages: list[dict[str, Any]] = field(default_factory=list)
+
+
+class TopicDebouncer:
+    """Batches messages per topic within a debounce window.
+
+    When messages arrive rapidly for the same topic, they are collected
+    and combined into a single batch after the debounce window expires.
+    This prevents multiple runner invocations when users send multiple
+    messages in quick succession.
+
+    Usage:
+        debouncer = TopicDebouncer(window_ms=200.0)
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(debouncer.run_timers)
+
+            async for update in poller(cfg):
+                msg = update["message"]
+                topic_id = msg.get("message_thread_id")
+
+                async for batch in debouncer.add(topic_id, msg):
+                    # Process the batch
+                    ...
+    """
+
+    def __init__(
+        self,
+        window_ms: float = 200.0,
+        clock: Callable[[], float] = time.monotonic,
+    ):
+        self.window_ms = window_ms
+        self.window_s = window_ms / 1000.0
+        self._clock = clock
+        self._pending: dict[int | None, list[PendingMessage]] = {}
+        self._deadlines: dict[int | None, float] = {}
+        self._ready_queue: list[MessageBatch] = []
+        self._new_message = anyio.Event()
+
+    def _is_slash_command(self, text: str) -> bool:
+        """Check if text is a slash command that should bypass debouncing."""
+        return text.strip().startswith("/")
+
+    def add_message(
+        self,
+        topic_id: int | None,
+        msg: dict[str, Any],
+    ) -> list[MessageBatch]:
+        """Add a message to the debounce queue.
+
+        Args:
+            topic_id: The topic ID (message_thread_id) or None for General.
+            msg: The raw Telegram message dict.
+
+        Returns:
+            List of batches ready to dispatch (may be empty, or contain
+            a flushed batch plus a slash command batch).
+        """
+        text = msg.get("text", "")
+        message_id = msg["message_id"]
+        reply_to = msg.get("reply_to_message")
+        ready_batches: list[MessageBatch] = []
+
+        # Slash commands bypass debouncing entirely
+        if self._is_slash_command(text):
+            # If there are pending messages for this topic, flush them first
+            if topic_id in self._pending and self._pending[topic_id]:
+                ready_batches.append(self._flush_topic(topic_id))
+
+            # Return the slash command as its own single-message batch
+            ready_batches.append(
+                MessageBatch(
+                    message_ids=[message_id],
+                    combined_text=text,
+                    first_reply_to=reply_to,
+                    last_message_id=message_id,
+                    topic_id=topic_id,
+                    raw_messages=[msg],
+                )
+            )
+            return ready_batches
+
+        # Add to pending queue
+        pending_msg = PendingMessage(
+            message_id=message_id,
+            text=text,
+            timestamp=self._clock(),
+            reply_to=reply_to,
+            raw_message=msg,
+        )
+
+        if topic_id not in self._pending:
+            self._pending[topic_id] = []
+
+        self._pending[topic_id].append(pending_msg)
+
+        # Update deadline for this topic (reset the timer)
+        self._deadlines[topic_id] = self._clock() + self.window_s
+
+        # Signal that we have a new message (wakes up the timer task)
+        self._new_message.set()
+
+        return ready_batches
+
+    def check_expired(self) -> list[MessageBatch]:
+        """Check for topics whose debounce window has expired.
+
+        Returns:
+            List of batches ready to dispatch.
+        """
+        ready_batches: list[MessageBatch] = []
+        now = self._clock()
+
+        expired_topics = [
+            topic_id
+            for topic_id, deadline in self._deadlines.items()
+            if now >= deadline
+        ]
+
+        for topic_id in expired_topics:
+            if topic_id in self._pending and self._pending[topic_id]:
+                ready_batches.append(self._flush_topic(topic_id))
+
+        return ready_batches
+
+    def _flush_topic(self, topic_id: int | None) -> MessageBatch:
+        """Flush a specific topic's pending messages into a batch."""
+        messages = self._pending.pop(topic_id, [])
+        self._deadlines.pop(topic_id, None)
+        return self._combine(topic_id, messages)
+
+    def _combine(
+        self, topic_id: int | None, messages: list[PendingMessage]
+    ) -> MessageBatch:
+        """Combine pending messages into a batch."""
+        return MessageBatch(
+            message_ids=[m.message_id for m in messages],
+            combined_text="\n".join(m.text for m in messages),
+            first_reply_to=messages[0].reply_to if messages else None,
+            last_message_id=messages[-1].message_id if messages else 0,
+            topic_id=topic_id,
+            raw_messages=[m.raw_message for m in messages],
+        )
+
+    def flush_all(self) -> list[MessageBatch]:
+        """Flush all pending batches immediately.
+
+        Returns:
+            List of all pending batches.
+        """
+        batches = []
+        for topic_id in list(self._pending.keys()):
+            if self._pending[topic_id]:
+                batches.append(self._flush_topic(topic_id))
+        return batches
+
+    def next_deadline(self) -> float | None:
+        """Get the next deadline across all topics.
+
+        Returns:
+            Timestamp of next deadline, or None if no pending messages.
+        """
+        if not self._deadlines:
+            return None
+        return min(self._deadlines.values())
+
+    def has_pending(self) -> bool:
+        """Check if there are any pending messages."""
+        return bool(self._pending)
 
 
 async def _send_startup(cfg: WorkspaceBridgeConfig) -> None:
@@ -473,6 +664,35 @@ async def _send_topic_result(
         await cfg.bot.delete_message(chat_id=chat_id, message_id=progress_id)
 
 
+async def _run_debounce_timer(
+    debouncer: TopicDebouncer,
+    on_batch: Callable[[MessageBatch], Awaitable[None]],
+) -> None:
+    """Background task that fires batches when debounce windows expire.
+
+    Args:
+        debouncer: The debouncer instance to check.
+        on_batch: Callback to process ready batches.
+    """
+    while True:
+        deadline = debouncer.next_deadline()
+        if deadline is None:
+            # No pending messages, wait for signal
+            debouncer._new_message = anyio.Event()
+            await debouncer._new_message.wait()
+        else:
+            now = time.monotonic()
+            wait_time = max(0, deadline - now)
+            if wait_time > 0:
+                with anyio.move_on_after(wait_time):
+                    debouncer._new_message = anyio.Event()
+                    await debouncer._new_message.wait()
+
+            # Check for expired batches
+            for batch in debouncer.check_expired():
+                await on_batch(batch)
+
+
 async def run_workspace_loop(
     cfg: WorkspaceBridgeConfig,
     poller: Callable[
@@ -482,6 +702,7 @@ async def run_workspace_loop(
     """Main loop for workspace mode."""
     running_tasks: dict[int, RunningTask] = {}
     chat_id = cfg.workspace.telegram_group_id
+    debouncer = TopicDebouncer(window_ms=cfg.workspace.message_batch_window_ms)
 
     try:
         # Set bot command menu
@@ -558,34 +779,34 @@ async def run_workspace_loop(
                 finally:
                     clear_context()
 
-            async for update in poller(cfg):
-                # Handle callback queries (inline button presses)
-                if update.get("_type") == "callback_query":
-                    await handle_callback_query(cfg, update["callback_query"])
-                    continue
+            async def process_batch(batch: MessageBatch) -> None:
+                """Process a batched message ready for dispatch."""
+                text = batch.combined_text
+                # Reply to the last message in the batch
+                user_msg_id = batch.last_message_id
+                message_thread_id = batch.topic_id
 
-                # Handle regular messages
-                msg = update.get("message")
-                if msg is None:
-                    continue
+                # Log batched messages
+                if len(batch.message_ids) > 1:
+                    logger.info(
+                        "debounce.batch",
+                        message_count=len(batch.message_ids),
+                        topic_id=message_thread_id,
+                        message_ids=batch.message_ids,
+                    )
 
-                text = msg["text"]
-                user_msg_id = msg["message_id"]
-                message_thread_id = msg.get("message_thread_id")
-
-                # Handle /cancel command
+                # Handle /cancel command (should have been caught by debouncer,
+                # but check here as well for safety)
                 if _is_cancel_command(text):
-                    # First, try to cancel a running task if replying to it
-                    reply = msg.get("reply_to_message")
+                    reply = batch.first_reply_to
                     if reply:
                         progress_id = reply.get("message_id")
                         if progress_id is not None:
                             running_task = running_tasks.get(int(progress_id))
                             if running_task is not None:
                                 running_task.cancel_requested.set()
-                                continue
+                                return
 
-                    # In worker topics, also try to cancel any active ralph loop
                     if message_thread_id is not None:
                         if cfg.ralph_manager.cancel_loop(message_thread_id):
                             await cfg.bot.send_message(
@@ -594,7 +815,7 @@ async def run_workspace_loop(
                                 message_thread_id=message_thread_id,
                                 reply_to_message_id=user_msg_id,
                             )
-                            continue
+                            return
 
                     await cfg.bot.send_message(
                         chat_id=chat_id,
@@ -602,7 +823,7 @@ async def run_workspace_loop(
                         message_thread_id=message_thread_id,
                         reply_to_message_id=user_msg_id,
                     )
-                    continue
+                    return
 
                 # Route the message
                 route = cfg.workspace_router.route(message_thread_id, text)
@@ -615,7 +836,7 @@ async def run_workspace_loop(
                         route,
                         user_msg_id,
                     )
-                    continue
+                    return
 
                 # Handle Ralph commands in worker topics
                 if (
@@ -630,7 +851,7 @@ async def run_workspace_loop(
                             message_thread_id=message_thread_id,
                             reply_to_message_id=user_msg_id,
                         )
-                        continue
+                        return
 
                     # Get runner for ralph loop
                     try:
@@ -642,7 +863,7 @@ async def run_workspace_loop(
                             message_thread_id=message_thread_id,
                             reply_to_message_id=user_msg_id,
                         )
-                        continue
+                        return
 
                     tg.start_soon(
                         partial(
@@ -654,7 +875,7 @@ async def run_workspace_loop(
                             runner=entry.runner,
                         ),
                     )
-                    continue
+                    return
 
                 # Reject non-ralph messages if ralph is active in this topic
                 if route.folder is not None and route.folder.topic_id is not None:
@@ -665,7 +886,7 @@ async def run_workspace_loop(
                             message_thread_id=message_thread_id,
                             reply_to_message_id=user_msg_id,
                         )
-                        continue
+                        return
 
                 # Handle unbound topic
                 if route.is_unbound_topic:
@@ -673,10 +894,10 @@ async def run_workspace_loop(
                         message_thread_id,  # type: ignore
                         user_msg_id,
                     )
-                    continue
+                    return
 
                 # Strip engine commands
-                text, engine_override = _strip_engine_command(
+                processed_text, engine_override = _strip_engine_command(
                     text, engine_ids=cfg.router.engine_ids
                 )
 
@@ -689,9 +910,11 @@ async def run_workspace_loop(
                     # Orchestrator in General topic - use workspace root
                     cwd = cfg.workspace.root
 
-                # Resolve resume token from reply
-                r = msg.get("reply_to_message") or {}
-                resume_token = cfg.router.resolve_resume(text, r.get("text"))
+                # Resolve resume token from the first message's reply
+                r = batch.first_reply_to or {}
+                resume_token = cfg.router.resolve_resume(
+                    processed_text, r.get("text")
+                )
 
                 # Check if replying to a running task
                 reply_id = r.get("message_id")
@@ -709,12 +932,12 @@ async def run_workspace_loop(
                                 reply_to_message_id=user_msg_id,
                                 disable_notification=True,
                             )
-                            continue
+                            return
 
                 # Inject orchestrator context for new General topic messages
-                job_text = text
+                job_text = processed_text
                 if route.is_general and resume_token is None:
-                    job_text = prepend_orchestrator_context(cfg.workspace, text)
+                    job_text = prepend_orchestrator_context(cfg.workspace, processed_text)
 
                 # Start the job
                 tg.start_soon(
@@ -726,6 +949,29 @@ async def run_workspace_loop(
                     cwd,
                     engine_override,
                 )
+
+            # Start the debounce timer background task
+            tg.start_soon(_run_debounce_timer, debouncer, process_batch)
+
+            async for update in poller(cfg):
+                # Handle callback queries (inline button presses)
+                if update.get("_type") == "callback_query":
+                    await handle_callback_query(cfg, update["callback_query"])
+                    continue
+
+                # Handle regular messages
+                msg = update.get("message")
+                if msg is None:
+                    continue
+
+                message_thread_id = msg.get("message_thread_id")
+
+                # Add message to debouncer
+                ready_batches = debouncer.add_message(message_thread_id, msg)
+
+                # Process any immediately-ready batches (slash commands)
+                for batch in ready_batches:
+                    await process_batch(batch)
 
     finally:
         await cfg.bot.close()

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import time
 from typing import Any
 
 import anyio
@@ -91,8 +90,12 @@ class TestTopicDebouncerSync:
         """Multiple messages to same topic should be queued together."""
         debouncer = TopicDebouncer(window_ms=200.0)
 
-        batches1 = debouncer.add_message(123, _make_msg(1, "hello", message_thread_id=123))
-        batches2 = debouncer.add_message(123, _make_msg(2, "world", message_thread_id=123))
+        batches1 = debouncer.add_message(
+            123, _make_msg(1, "hello", message_thread_id=123)
+        )
+        batches2 = debouncer.add_message(
+            123, _make_msg(2, "world", message_thread_id=123)
+        )
 
         assert batches1 == []
         assert batches2 == []
@@ -128,9 +131,7 @@ class TestTopicDebouncerSync:
         debouncer = TopicDebouncer(window_ms=200.0)
         reply = {"message_id": 100, "text": "previous message"}
 
-        debouncer.add_message(
-            None, _make_msg(1, "first", reply_to_message=reply)
-        )
+        debouncer.add_message(None, _make_msg(1, "first", reply_to_message=reply))
         debouncer.add_message(None, _make_msg(2, "second"))
 
         flushed = debouncer.flush_all()

--- a/tests/test_debouncer.py
+++ b/tests/test_debouncer.py
@@ -1,0 +1,433 @@
+"""Tests for the TopicDebouncer message batching logic."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import anyio
+import pytest
+
+from pochi.workspace.bridge import (
+    MessageBatch,
+    PendingMessage,
+    TopicDebouncer,
+    _run_debounce_timer,
+)
+
+
+def _make_msg(
+    message_id: int,
+    text: str,
+    *,
+    message_thread_id: int | None = None,
+    reply_to_message: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Create a minimal Telegram message dict for testing."""
+    msg: dict[str, Any] = {
+        "message_id": message_id,
+        "text": text,
+        "chat": {"id": 123},
+    }
+    if message_thread_id is not None:
+        msg["message_thread_id"] = message_thread_id
+    if reply_to_message is not None:
+        msg["reply_to_message"] = reply_to_message
+    return msg
+
+
+class TestTopicDebouncerSync:
+    """Tests for synchronous TopicDebouncer methods."""
+
+    def test_slash_command_bypasses_debounce(self) -> None:
+        """Slash commands should be returned immediately without debouncing."""
+        debouncer = TopicDebouncer(window_ms=200.0)
+        msg = _make_msg(1, "/help")
+
+        batches = debouncer.add_message(None, msg)
+
+        assert len(batches) == 1
+        batch = batches[0]
+        assert batch.combined_text == "/help"
+        assert batch.message_ids == [1]
+        assert batch.last_message_id == 1
+        assert batch.topic_id is None
+        assert not debouncer.has_pending()
+
+    def test_slash_command_flushes_pending(self) -> None:
+        """Slash command should flush any pending messages for the same topic."""
+        debouncer = TopicDebouncer(window_ms=200.0)
+
+        # Add a regular message
+        batches1 = debouncer.add_message(None, _make_msg(1, "hello"))
+        assert batches1 == []
+        assert debouncer.has_pending()
+
+        # Add slash command - should flush pending first
+        batches2 = debouncer.add_message(None, _make_msg(2, "/help"))
+        assert len(batches2) == 2
+
+        # First batch is the flushed pending message
+        assert batches2[0].combined_text == "hello"
+        assert batches2[0].message_ids == [1]
+
+        # Second batch is the slash command
+        assert batches2[1].combined_text == "/help"
+        assert batches2[1].message_ids == [2]
+
+        assert not debouncer.has_pending()
+
+    def test_regular_message_queued(self) -> None:
+        """Regular messages should be queued without immediate batching."""
+        debouncer = TopicDebouncer(window_ms=200.0)
+        msg = _make_msg(1, "hello")
+
+        batches = debouncer.add_message(None, msg)
+
+        assert batches == []
+        assert debouncer.has_pending()
+
+    def test_multiple_messages_same_topic(self) -> None:
+        """Multiple messages to same topic should be queued together."""
+        debouncer = TopicDebouncer(window_ms=200.0)
+
+        batches1 = debouncer.add_message(123, _make_msg(1, "hello", message_thread_id=123))
+        batches2 = debouncer.add_message(123, _make_msg(2, "world", message_thread_id=123))
+
+        assert batches1 == []
+        assert batches2 == []
+        assert debouncer.has_pending()
+
+        # Flush to check combined content
+        flushed = debouncer.flush_all()
+        assert len(flushed) == 1
+        assert flushed[0].combined_text == "hello\nworld"
+        assert flushed[0].message_ids == [1, 2]
+        assert flushed[0].last_message_id == 2
+        assert flushed[0].topic_id == 123
+
+    def test_messages_different_topics(self) -> None:
+        """Messages to different topics should be in separate pending queues."""
+        debouncer = TopicDebouncer(window_ms=200.0)
+
+        debouncer.add_message(123, _make_msg(1, "topic 123", message_thread_id=123))
+        debouncer.add_message(456, _make_msg(2, "topic 456", message_thread_id=456))
+        debouncer.add_message(None, _make_msg(3, "general"))
+
+        flushed = debouncer.flush_all()
+        assert len(flushed) == 3
+
+        # Sort by topic_id for deterministic testing
+        texts = {b.topic_id: b.combined_text for b in flushed}
+        assert texts[123] == "topic 123"
+        assert texts[456] == "topic 456"
+        assert texts[None] == "general"
+
+    def test_first_reply_preserved(self) -> None:
+        """First message's reply_to should be preserved in batch."""
+        debouncer = TopicDebouncer(window_ms=200.0)
+        reply = {"message_id": 100, "text": "previous message"}
+
+        debouncer.add_message(
+            None, _make_msg(1, "first", reply_to_message=reply)
+        )
+        debouncer.add_message(None, _make_msg(2, "second"))
+
+        flushed = debouncer.flush_all()
+        assert len(flushed) == 1
+        assert flushed[0].first_reply_to == reply
+
+    def test_flush_all_clears_state(self) -> None:
+        """flush_all should clear all pending state."""
+        debouncer = TopicDebouncer(window_ms=200.0)
+
+        debouncer.add_message(123, _make_msg(1, "hello", message_thread_id=123))
+        debouncer.add_message(456, _make_msg(2, "world", message_thread_id=456))
+
+        assert debouncer.has_pending()
+        debouncer.flush_all()
+        assert not debouncer.has_pending()
+
+    def test_check_expired_with_fake_clock(self) -> None:
+        """check_expired should return batches whose window has expired."""
+        clock_value = [0.0]
+
+        def fake_clock() -> float:
+            return clock_value[0]
+
+        debouncer = TopicDebouncer(window_ms=200.0, clock=fake_clock)
+
+        # Add message at t=0
+        clock_value[0] = 0.0
+        debouncer.add_message(None, _make_msg(1, "hello"))
+
+        # Check at t=100ms - not expired yet
+        clock_value[0] = 0.1
+        batches = debouncer.check_expired()
+        assert batches == []
+        assert debouncer.has_pending()
+
+        # Check at t=200ms - should be expired
+        clock_value[0] = 0.2
+        batches = debouncer.check_expired()
+        assert len(batches) == 1
+        assert batches[0].combined_text == "hello"
+        assert not debouncer.has_pending()
+
+    def test_new_message_resets_deadline(self) -> None:
+        """Adding a new message should reset the debounce deadline."""
+        clock_value = [0.0]
+
+        def fake_clock() -> float:
+            return clock_value[0]
+
+        debouncer = TopicDebouncer(window_ms=200.0, clock=fake_clock)
+
+        # Add first message at t=0
+        clock_value[0] = 0.0
+        debouncer.add_message(None, _make_msg(1, "first"))
+
+        # Add second message at t=150ms
+        clock_value[0] = 0.15
+        debouncer.add_message(None, _make_msg(2, "second"))
+
+        # Check at t=200ms - should NOT be expired (deadline reset to t=350ms)
+        clock_value[0] = 0.2
+        batches = debouncer.check_expired()
+        assert batches == []
+        assert debouncer.has_pending()
+
+        # Check at t=350ms - should be expired
+        clock_value[0] = 0.35
+        batches = debouncer.check_expired()
+        assert len(batches) == 1
+        assert batches[0].combined_text == "first\nsecond"
+
+    def test_next_deadline(self) -> None:
+        """next_deadline should return the soonest deadline."""
+        clock_value = [0.0]
+
+        def fake_clock() -> float:
+            return clock_value[0]
+
+        debouncer = TopicDebouncer(window_ms=200.0, clock=fake_clock)
+
+        # No pending - no deadline
+        assert debouncer.next_deadline() is None
+
+        # Add message at t=0
+        clock_value[0] = 0.0
+        debouncer.add_message(123, _make_msg(1, "hello", message_thread_id=123))
+        assert debouncer.next_deadline() == 0.2
+
+        # Add message to another topic at t=100ms
+        clock_value[0] = 0.1
+        debouncer.add_message(456, _make_msg(2, "world", message_thread_id=456))
+
+        # Earliest deadline is still 0.2 (topic 123)
+        assert debouncer.next_deadline() == 0.2
+
+    def test_raw_messages_preserved(self) -> None:
+        """raw_messages should contain the original message dicts."""
+        debouncer = TopicDebouncer(window_ms=200.0)
+
+        msg1 = _make_msg(1, "first")
+        msg2 = _make_msg(2, "second")
+
+        debouncer.add_message(None, msg1)
+        debouncer.add_message(None, msg2)
+
+        flushed = debouncer.flush_all()
+        assert len(flushed) == 1
+        assert flushed[0].raw_messages == [msg1, msg2]
+
+
+class TestTopicDebouncerAsync:
+    """Async tests for debouncer timer behavior."""
+
+    @pytest.mark.anyio
+    async def test_timer_fires_batch(self) -> None:
+        """Timer should fire batches after window expires."""
+        debouncer = TopicDebouncer(window_ms=50.0)
+        received_batches: list[MessageBatch] = []
+
+        async def on_batch(batch: MessageBatch) -> None:
+            received_batches.append(batch)
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_run_debounce_timer, debouncer, on_batch)
+
+            # Add a message
+            debouncer.add_message(None, _make_msg(1, "hello"))
+
+            # Wait for timer to fire (50ms + some margin)
+            await anyio.sleep(0.1)
+
+            # Should have received the batch
+            assert len(received_batches) == 1
+            assert received_batches[0].combined_text == "hello"
+
+            tg.cancel_scope.cancel()
+
+    @pytest.mark.anyio
+    async def test_timer_waits_for_messages(self) -> None:
+        """Timer should wait when no pending messages."""
+        debouncer = TopicDebouncer(window_ms=50.0)
+        received_batches: list[MessageBatch] = []
+
+        async def on_batch(batch: MessageBatch) -> None:
+            received_batches.append(batch)
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_run_debounce_timer, debouncer, on_batch)
+
+            # Wait without adding messages
+            await anyio.sleep(0.1)
+            assert received_batches == []
+
+            # Now add a message
+            debouncer.add_message(None, _make_msg(1, "hello"))
+
+            # Wait for timer to fire
+            await anyio.sleep(0.1)
+            assert len(received_batches) == 1
+
+            tg.cancel_scope.cancel()
+
+    @pytest.mark.anyio
+    async def test_batching_rapid_messages(self) -> None:
+        """Rapid messages should be batched together."""
+        debouncer = TopicDebouncer(window_ms=100.0)
+        received_batches: list[MessageBatch] = []
+
+        async def on_batch(batch: MessageBatch) -> None:
+            received_batches.append(batch)
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_run_debounce_timer, debouncer, on_batch)
+
+            # Add messages rapidly (within the 100ms window)
+            debouncer.add_message(None, _make_msg(1, "hello"))
+            await anyio.sleep(0.02)  # 20ms
+            debouncer.add_message(None, _make_msg(2, "world"))
+            await anyio.sleep(0.02)  # 40ms total
+            debouncer.add_message(None, _make_msg(3, "!"))
+
+            # Wait for batch - deadline should be ~100ms after last message
+            await anyio.sleep(0.15)
+
+            # Should have received a single batch with all three messages
+            assert len(received_batches) == 1
+            assert received_batches[0].combined_text == "hello\nworld\n!"
+            assert received_batches[0].message_ids == [1, 2, 3]
+
+            tg.cancel_scope.cancel()
+
+    @pytest.mark.anyio
+    async def test_separate_batches_for_slow_messages(self) -> None:
+        """Messages sent after window expires should be in separate batches."""
+        debouncer = TopicDebouncer(window_ms=50.0)
+        received_batches: list[MessageBatch] = []
+
+        async def on_batch(batch: MessageBatch) -> None:
+            received_batches.append(batch)
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_run_debounce_timer, debouncer, on_batch)
+
+            # First message
+            debouncer.add_message(None, _make_msg(1, "first"))
+
+            # Wait for it to be batched
+            await anyio.sleep(0.1)
+            assert len(received_batches) == 1
+            assert received_batches[0].combined_text == "first"
+
+            # Second message (after window expired)
+            debouncer.add_message(None, _make_msg(2, "second"))
+
+            # Wait for second batch
+            await anyio.sleep(0.1)
+            assert len(received_batches) == 2
+            assert received_batches[1].combined_text == "second"
+
+            tg.cancel_scope.cancel()
+
+    @pytest.mark.anyio
+    async def test_independent_topic_batching(self) -> None:
+        """Different topics should batch independently."""
+        debouncer = TopicDebouncer(window_ms=50.0)
+        received_batches: list[MessageBatch] = []
+
+        async def on_batch(batch: MessageBatch) -> None:
+            received_batches.append(batch)
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_run_debounce_timer, debouncer, on_batch)
+
+            # Add messages to different topics
+            debouncer.add_message(123, _make_msg(1, "topic 123", message_thread_id=123))
+            debouncer.add_message(456, _make_msg(2, "topic 456", message_thread_id=456))
+
+            # Wait for both to be batched
+            await anyio.sleep(0.1)
+
+            assert len(received_batches) == 2
+            topic_texts = {b.topic_id: b.combined_text for b in received_batches}
+            assert topic_texts[123] == "topic 123"
+            assert topic_texts[456] == "topic 456"
+
+            tg.cancel_scope.cancel()
+
+
+class TestPendingMessageDataclass:
+    """Tests for PendingMessage dataclass."""
+
+    def test_fields(self) -> None:
+        """Verify PendingMessage fields."""
+        raw = _make_msg(1, "hello")
+        pending = PendingMessage(
+            message_id=1,
+            text="hello",
+            timestamp=1234.5,
+            reply_to=None,
+            raw_message=raw,
+        )
+        assert pending.message_id == 1
+        assert pending.text == "hello"
+        assert pending.timestamp == 1234.5
+        assert pending.reply_to is None
+        assert pending.raw_message == raw
+
+
+class TestMessageBatchDataclass:
+    """Tests for MessageBatch dataclass."""
+
+    def test_fields(self) -> None:
+        """Verify MessageBatch fields."""
+        raw = [_make_msg(1, "hello")]
+        batch = MessageBatch(
+            message_ids=[1],
+            combined_text="hello",
+            first_reply_to=None,
+            last_message_id=1,
+            topic_id=123,
+            raw_messages=raw,
+        )
+        assert batch.message_ids == [1]
+        assert batch.combined_text == "hello"
+        assert batch.first_reply_to is None
+        assert batch.last_message_id == 1
+        assert batch.topic_id == 123
+        assert batch.raw_messages == raw
+
+    def test_default_raw_messages(self) -> None:
+        """raw_messages should default to empty list."""
+        batch = MessageBatch(
+            message_ids=[1],
+            combined_text="hello",
+            first_reply_to=None,
+            last_message_id=1,
+            topic_id=None,
+        )
+        assert batch.raw_messages == []


### PR DESCRIPTION
## Summary

- Implement `TopicDebouncer` class that batches messages per topic within a configurable debounce window (default 200ms)
- Integrate debouncer into `run_workspace_loop()` with a background timer task
- Add `message_batch_window_ms` configuration option to workspace settings
- Slash commands bypass debouncing and are processed immediately
- Resume tokens are extracted from the first message in a batch
- Bot replies are sent to the last message in a batch

## Test plan

- [x] Run `uv run pytest tests/test_debouncer.py` - 19 tests covering sync and async debouncer behavior
- [x] Run `uv run pytest` - All 573 tests pass with 60.66% coverage
- [x] Verify config loading with custom `message_batch_window_ms` values

Fixes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)