### PR TITLE
feat: Add @branch directive for git worktree support

### DIFF
--- a/src/pochi/config.py
+++ b/src/pochi/config.py
@@ -93,6 +93,12 @@ class WorkspaceConfig:
     ralph: RalphConfig = field(default_factory=RalphConfig)
     default_engine: str = "claude"
 
+    # Worktree settings
+    worktrees_dir: str = ".worktrees"  # Directory name for worktrees within folders
+    worktree_base: str | None = (
+        None  # Base branch for new worktrees (auto-detect if None)
+    )
+
     # Transport configs
     telegram: TelegramConfig | None = None
 
@@ -168,6 +174,8 @@ def _settings_to_config(settings: WorkspaceSettings, root: Path) -> WorkspaceCon
         folders=folders,
         ralph=ralph,
         default_engine=settings.default_engine,
+        worktrees_dir=settings.worktrees_dir,
+        worktree_base=settings.worktree_base,
         telegram=telegram,
         telegram_group_id=telegram_group_id,
         bot_token=bot_token,
@@ -209,6 +217,10 @@ def save_workspace_config(config: WorkspaceConfig) -> None:
     workspace.add("name", config.name)
     if config.default_engine != "claude":
         workspace.add("default_engine", config.default_engine)
+    if config.worktrees_dir != ".worktrees":
+        workspace.add("worktrees_dir", config.worktrees_dir)
+    if config.worktree_base:
+        workspace.add("worktree_base", config.worktree_base)
     doc.add("workspace", workspace)
 
     # [telegram] section (new format)

--- a/src/pochi/context.py
+++ b/src/pochi/context.py
@@ -1,0 +1,82 @@
+"""Run context for tracking folder and branch state during execution."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class RunContext:
+    """Context for a single agent run, tracking folder and optional branch.
+
+    This context is included in message footers and used to route replies
+    back to the correct worktree.
+    """
+
+    folder: str
+    branch: str | None = None
+
+    def format_footer(self) -> str:
+        """Format the context as a footer line for messages.
+
+        Returns:
+            A string like "`ctx: folder @ branch`" or "`ctx: folder`".
+        """
+        if self.branch:
+            return f"`ctx: {self.folder} @ {self.branch}`"
+        return f"`ctx: {self.folder}`"
+
+    @classmethod
+    def parse(cls, text: str) -> "RunContext | None":
+        """Parse a RunContext from message text containing a ctx: footer.
+
+        Args:
+            text: Message text that may contain a ctx: footer.
+
+        Returns:
+            RunContext if found, None otherwise.
+        """
+        # Look for `ctx: folder @ branch` or `ctx: folder`
+        # Match backtick-wrapped format
+        pattern = r"`ctx:\s*([^@`]+?)(?:\s*@\s*([^`]+))?`"
+        match = re.search(pattern, text)
+        if not match:
+            return None
+
+        folder = match.group(1).strip()
+        branch = match.group(2).strip() if match.group(2) else None
+
+        if not folder:
+            return None
+
+        return cls(folder=folder, branch=branch)
+
+
+def resolve_run_path(
+    workspace_root: Path,
+    folder_path: str,
+    branch: str | None,
+    *,
+    worktrees_dir: str = ".worktrees",
+) -> Path:
+    """Resolve the actual working directory for a run.
+
+    Args:
+        workspace_root: Absolute path to workspace root.
+        folder_path: Relative path to the folder from workspace root.
+        branch: Branch name (if using worktree), or None for main checkout.
+        worktrees_dir: Directory name for worktrees.
+
+    Returns:
+        Absolute path to use as working directory.
+    """
+    folder_abs = workspace_root / folder_path
+
+    if branch is None:
+        return folder_abs
+
+    # Convert branch slashes to double underscores for filesystem
+    safe_branch = branch.replace("/", "__")
+    return folder_abs / worktrees_dir / safe_branch

--- a/src/pochi/settings.py
+++ b/src/pochi/settings.py
@@ -77,6 +77,12 @@ class WorkspaceSettings(BaseSettings):
     name: str = ""
     default_engine: str = "claude"
 
+    # Worktree settings
+    worktrees_dir: str = ".worktrees"  # Directory name for worktrees within folders
+    worktree_base: str | None = (
+        None  # Base branch for new worktrees (auto-detect if None)
+    )
+
     # Transport config
     telegram: TelegramSettings | None = None
 
@@ -208,6 +214,8 @@ def load_settings(workspace_root: Path | None = None) -> WorkspaceSettings | Non
         settings = WorkspaceSettings(
             name=workspace_data.get("name", workspace_root.name),
             default_engine=workspace_data.get("default_engine", "claude"),
+            worktrees_dir=workspace_data.get("worktrees_dir", ".worktrees"),
+            worktree_base=workspace_data.get("worktree_base"),
             telegram=_parse_telegram(data),
             folders=_parse_folders(data),
             ralph=_parse_ralph(data),

--- a/src/pochi/utils/git.py
+++ b/src/pochi/utils/git.py
@@ -1,0 +1,232 @@
+"""Git utility functions for working with repositories."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from ..logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class GitError(Exception):
+    """Error from a git operation."""
+
+    def __init__(self, message: str, returncode: int = 1, stderr: str = "") -> None:
+        super().__init__(message)
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+def run_git(
+    *args: str,
+    cwd: Path | None = None,
+    timeout: float = 60.0,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Run a git command and return the result.
+
+    Args:
+        *args: Git command arguments (without 'git' prefix).
+        cwd: Working directory for the command.
+        timeout: Command timeout in seconds.
+        check: If True, raise GitError on non-zero exit.
+
+    Returns:
+        CompletedProcess with stdout/stderr.
+
+    Raises:
+        GitError: If check=True and command fails.
+    """
+    cmd = ["git", *args]
+    logger.debug("git.run", cmd=cmd, cwd=str(cwd) if cwd else None)
+
+    result = subprocess.run(
+        cmd,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+    if check and result.returncode != 0:
+        raise GitError(
+            f"git {args[0]} failed: {result.stderr.strip() or result.stdout.strip()}",
+            returncode=result.returncode,
+            stderr=result.stderr,
+        )
+
+    return result
+
+
+def is_git_repo(path: Path) -> bool:
+    """Check if a path is inside a git repository."""
+    git_dir = path / ".git"
+    return git_dir.exists()
+
+
+def get_current_branch(cwd: Path) -> str | None:
+    """Get the current branch name, or None if detached/not a repo."""
+    try:
+        result = run_git("rev-parse", "--abbrev-ref", "HEAD", cwd=cwd)
+        branch = result.stdout.strip()
+        return branch if branch and branch != "HEAD" else None
+    except (GitError, subprocess.TimeoutExpired):
+        return None
+
+
+def get_default_branch(cwd: Path) -> str:
+    """Get the default branch to use as base for new branches.
+
+    Checks in order: origin/HEAD, origin/main, origin/master, current branch.
+    Falls back to "main" if nothing found.
+    """
+    # Try origin/HEAD
+    try:
+        result = run_git(
+            "symbolic-ref", "refs/remotes/origin/HEAD", cwd=cwd, check=False
+        )
+        if result.returncode == 0:
+            ref = result.stdout.strip()
+            # refs/remotes/origin/main -> main
+            if ref.startswith("refs/remotes/origin/"):
+                return ref.split("/")[-1]
+    except subprocess.TimeoutExpired:
+        pass
+
+    # Try common default branches
+    for branch in ("main", "master"):
+        try:
+            result = run_git(
+                "rev-parse", "--verify", f"origin/{branch}", cwd=cwd, check=False
+            )
+            if result.returncode == 0:
+                return branch
+        except subprocess.TimeoutExpired:
+            continue
+
+    # Fall back to current branch
+    current = get_current_branch(cwd)
+    if current:
+        return current
+
+    return "main"
+
+
+def branch_exists(branch: str, cwd: Path) -> bool:
+    """Check if a local branch exists."""
+    result = run_git("rev-parse", "--verify", branch, cwd=cwd, check=False)
+    return result.returncode == 0
+
+
+def remote_branch_exists(branch: str, cwd: Path, remote: str = "origin") -> bool:
+    """Check if a remote branch exists."""
+    result = run_git(
+        "rev-parse", "--verify", f"{remote}/{branch}", cwd=cwd, check=False
+    )
+    return result.returncode == 0
+
+
+def list_worktrees(cwd: Path) -> list[dict[str, str]]:
+    """List all worktrees for a repository.
+
+    Returns:
+        List of dicts with 'path', 'commit', and 'branch' keys.
+    """
+    try:
+        result = run_git("worktree", "list", "--porcelain", cwd=cwd)
+    except GitError:
+        return []
+
+    worktrees: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+
+    for line in result.stdout.splitlines():
+        if not line:
+            if current:
+                worktrees.append(current)
+                current = {}
+            continue
+
+        if line.startswith("worktree "):
+            current["path"] = line[9:]
+        elif line.startswith("HEAD "):
+            current["commit"] = line[5:]
+        elif line.startswith("branch "):
+            # refs/heads/feature/foo -> feature/foo
+            ref = line[7:]
+            if ref.startswith("refs/heads/"):
+                current["branch"] = ref[11:]
+            else:
+                current["branch"] = ref
+        elif line == "detached":
+            current["branch"] = ""
+
+    if current:
+        worktrees.append(current)
+
+    return worktrees
+
+
+def worktree_exists(worktree_path: Path, cwd: Path) -> bool:
+    """Check if a worktree exists at the given path."""
+    worktrees = list_worktrees(cwd)
+    worktree_str = str(worktree_path.resolve())
+    return any(wt.get("path") == worktree_str for wt in worktrees)
+
+
+def add_worktree(
+    worktree_path: Path,
+    branch: str,
+    cwd: Path,
+    *,
+    create_branch: bool = False,
+    base_ref: str | None = None,
+    timeout: float = 120.0,
+) -> None:
+    """Add a new worktree.
+
+    Args:
+        worktree_path: Path where the worktree should be created.
+        branch: Branch name to checkout in the worktree.
+        cwd: Repository root path.
+        create_branch: If True, create the branch with -b flag.
+        base_ref: Base ref for new branch (used with create_branch).
+        timeout: Command timeout in seconds.
+    """
+    args = ["worktree", "add"]
+
+    if create_branch:
+        args.extend(["-b", branch])
+        args.append(str(worktree_path))
+        if base_ref:
+            args.append(base_ref)
+    else:
+        args.append(str(worktree_path))
+        args.append(branch)
+
+    run_git(*args, cwd=cwd, timeout=timeout)
+    logger.info(
+        "git.worktree.added",
+        path=str(worktree_path),
+        branch=branch,
+        created=create_branch,
+    )
+
+
+def remove_worktree(worktree_path: Path, cwd: Path, *, force: bool = False) -> None:
+    """Remove a worktree.
+
+    Args:
+        worktree_path: Path to the worktree to remove.
+        cwd: Repository root path.
+        force: If True, force removal even if dirty.
+    """
+    args = ["worktree", "remove"]
+    if force:
+        args.append("--force")
+    args.append(str(worktree_path))
+
+    run_git(*args, cwd=cwd)
+    logger.info("git.worktree.removed", path=str(worktree_path))

--- a/src/pochi/worktrees.py
+++ b/src/pochi/worktrees.py
@@ -1,0 +1,266 @@
+"""Git worktree management for isolated branch execution.
+
+This module provides worktree creation and management, enabling the @branch
+directive to run agent sessions in isolated git worktrees.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from .logging import get_logger
+from .utils.git import (
+    GitError,
+    add_worktree,
+    branch_exists,
+    get_default_branch,
+    is_git_repo,
+    list_worktrees,
+    remote_branch_exists,
+    worktree_exists,
+)
+
+logger = get_logger(__name__)
+
+# Default directory name for worktrees within a folder
+DEFAULT_WORKTREES_DIR = ".worktrees"
+
+# Pattern for valid branch names (git branch naming rules, simplified)
+# Allows alphanumeric, /, -, _, .
+BRANCH_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$")
+
+
+class WorktreeError(Exception):
+    """Error during worktree operation."""
+
+    pass
+
+
+def sanitize_branch_name(name: str) -> str:
+    """Sanitize a branch name for safe filesystem and git usage.
+
+    - Strips leading/trailing whitespace
+    - Replaces spaces with hyphens
+    - Removes invalid characters
+    - Collapses consecutive separators
+
+    Args:
+        name: Raw branch name from user input.
+
+    Returns:
+        Sanitized branch name.
+
+    Raises:
+        ValueError: If the resulting name is empty or invalid.
+    """
+    if not name:
+        raise ValueError("Branch name cannot be empty")
+
+    # Strip whitespace
+    name = name.strip()
+
+    # Replace spaces with hyphens
+    name = name.replace(" ", "-")
+
+    # Remove leading slashes (git doesn't like /foo)
+    name = name.lstrip("/")
+
+    # Remove .. sequences (security/git issue)
+    while ".." in name:
+        name = name.replace("..", ".")
+
+    # Collapse consecutive slashes
+    while "//" in name:
+        name = name.replace("//", "/")
+
+    # Collapse consecutive hyphens
+    while "--" in name:
+        name = name.replace("--", "-")
+
+    # Remove trailing slashes and dots
+    name = name.rstrip("/.")
+
+    # Final validation
+    if not name:
+        raise ValueError("Branch name cannot be empty after sanitization")
+
+    # Check for valid characters
+    if not BRANCH_NAME_RE.match(name):
+        raise ValueError(f"Invalid branch name: {name}")
+
+    return name
+
+
+def get_worktree_path(
+    folder_path: Path,
+    branch: str,
+    worktrees_dir: str = DEFAULT_WORKTREES_DIR,
+) -> Path:
+    """Get the path where a worktree for a branch should be located.
+
+    Args:
+        folder_path: Path to the main repository folder.
+        branch: Branch name.
+        worktrees_dir: Directory name for worktrees (relative to folder).
+
+    Returns:
+        Absolute path to the worktree directory.
+    """
+    # Convert branch slashes to double underscores for filesystem safety
+    # e.g., feature/foo -> feature__foo
+    safe_name = branch.replace("/", "__")
+    return folder_path / worktrees_dir / safe_name
+
+
+def ensure_worktree(
+    folder_path: Path,
+    branch: str,
+    *,
+    worktrees_dir: str = DEFAULT_WORKTREES_DIR,
+    base_branch: str | None = None,
+) -> Path:
+    """Ensure a worktree exists for the given branch, creating if needed.
+
+    Auto-creation logic:
+    1. If worktree exists → use it
+    2. If local branch exists → git worktree add <path> <branch>
+    3. If origin/<branch> exists → git worktree add -b <branch> <path> origin/<branch>
+    4. Otherwise → create new branch from base (default branch)
+
+    Args:
+        folder_path: Path to the main repository folder.
+        branch: Branch name to use/create.
+        worktrees_dir: Directory name for worktrees.
+        base_branch: Base branch for new branches (auto-detected if None).
+
+    Returns:
+        Path to the worktree directory.
+
+    Raises:
+        WorktreeError: If worktree creation fails.
+    """
+    if not is_git_repo(folder_path):
+        raise WorktreeError(f"Not a git repository: {folder_path}")
+
+    worktree_path = get_worktree_path(folder_path, branch, worktrees_dir)
+
+    # Case 1: Worktree already exists
+    if worktree_exists(worktree_path, folder_path):
+        logger.info(
+            "worktree.reused",
+            path=str(worktree_path),
+            branch=branch,
+        )
+        return worktree_path
+
+    # Create parent directory if needed
+    worktree_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        # Case 2: Local branch exists
+        if branch_exists(branch, folder_path):
+            logger.info(
+                "worktree.creating.local_branch",
+                branch=branch,
+                path=str(worktree_path),
+            )
+            add_worktree(worktree_path, branch, folder_path)
+            return worktree_path
+
+        # Case 3: Remote branch exists
+        if remote_branch_exists(branch, folder_path):
+            logger.info(
+                "worktree.creating.remote_branch",
+                branch=branch,
+                path=str(worktree_path),
+            )
+            add_worktree(
+                worktree_path,
+                branch,
+                folder_path,
+                create_branch=True,
+                base_ref=f"origin/{branch}",
+            )
+            return worktree_path
+
+        # Case 4: New branch from base
+        if base_branch is None:
+            base_branch = get_default_branch(folder_path)
+
+        logger.info(
+            "worktree.creating.new_branch",
+            branch=branch,
+            base=base_branch,
+            path=str(worktree_path),
+        )
+
+        # Determine base ref - prefer origin/base if it exists
+        if remote_branch_exists(base_branch, folder_path):
+            base_ref = f"origin/{base_branch}"
+        elif branch_exists(base_branch, folder_path):
+            base_ref = base_branch
+        else:
+            # Last resort: HEAD
+            base_ref = "HEAD"
+
+        add_worktree(
+            worktree_path,
+            branch,
+            folder_path,
+            create_branch=True,
+            base_ref=base_ref,
+        )
+        return worktree_path
+
+    except GitError as e:
+        raise WorktreeError(f"Failed to create worktree: {e}") from e
+
+
+def find_worktree_for_path(path: Path, repo_path: Path) -> str | None:
+    """Find which branch a worktree path corresponds to.
+
+    Args:
+        path: Path that might be a worktree.
+        repo_path: Main repository path.
+
+    Returns:
+        Branch name if path is a worktree, None otherwise.
+    """
+    worktrees = list_worktrees(repo_path)
+    path_str = str(path.resolve())
+
+    for wt in worktrees:
+        if wt.get("path") == path_str:
+            return wt.get("branch")
+
+    return None
+
+
+def get_active_worktrees(
+    folder_path: Path,
+    worktrees_dir: str = DEFAULT_WORKTREES_DIR,
+) -> list[tuple[str, Path]]:
+    """Get all active worktrees for a folder.
+
+    Args:
+        folder_path: Path to the main repository folder.
+        worktrees_dir: Directory name for worktrees.
+
+    Returns:
+        List of (branch_name, worktree_path) tuples.
+    """
+    worktrees_path = folder_path / worktrees_dir
+    if not worktrees_path.exists():
+        return []
+
+    result: list[tuple[str, Path]] = []
+    worktrees = list_worktrees(folder_path)
+
+    for wt in worktrees:
+        wt_path = wt.get("path", "")
+        branch = wt.get("branch", "")
+        if wt_path.startswith(str(worktrees_path)) and branch:
+            result.append((branch, Path(wt_path)))
+
+    return result

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,113 @@
+"""Tests for pochi.context module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pochi.context import RunContext, resolve_run_path
+
+
+class TestRunContext:
+    """Tests for RunContext dataclass."""
+
+    def test_format_footer_with_branch(self) -> None:
+        """Test format_footer with branch returns ctx: folder @ branch format."""
+        ctx = RunContext(folder="backend", branch="feature/auth")
+        assert ctx.format_footer() == "`ctx: backend @ feature/auth`"
+
+    def test_format_footer_without_branch(self) -> None:
+        """Test format_footer without branch returns ctx: folder format."""
+        ctx = RunContext(folder="backend")
+        assert ctx.format_footer() == "`ctx: backend`"
+
+    def test_parse_with_branch(self) -> None:
+        """Test parsing context with branch from message text."""
+        text = (
+            "Some response\n\n`ctx: backend @ feature/auth`\n`claude --resume abc123`"
+        )
+        ctx = RunContext.parse(text)
+
+        assert ctx is not None
+        assert ctx.folder == "backend"
+        assert ctx.branch == "feature/auth"
+
+    def test_parse_without_branch(self) -> None:
+        """Test parsing context without branch from message text."""
+        text = "Some response\n\n`ctx: backend`\n`claude --resume abc123`"
+        ctx = RunContext.parse(text)
+
+        assert ctx is not None
+        assert ctx.folder == "backend"
+        assert ctx.branch is None
+
+    def test_parse_no_context(self) -> None:
+        """Test parsing returns None when no context footer found."""
+        text = "Some response without context footer"
+        ctx = RunContext.parse(text)
+        assert ctx is None
+
+    def test_parse_empty_string(self) -> None:
+        """Test parsing empty string returns None."""
+        ctx = RunContext.parse("")
+        assert ctx is None
+
+    def test_parse_strips_whitespace(self) -> None:
+        """Test parsing strips whitespace from folder and branch."""
+        text = "`ctx:  backend  @  feature/foo  `"
+        ctx = RunContext.parse(text)
+
+        assert ctx is not None
+        assert ctx.folder == "backend"
+        assert ctx.branch == "feature/foo"
+
+    def test_parse_complex_branch_name(self) -> None:
+        """Test parsing complex branch name with slashes and hyphens."""
+        text = "`ctx: my-repo @ feature/user-auth_v2`"
+        ctx = RunContext.parse(text)
+
+        assert ctx is not None
+        assert ctx.folder == "my-repo"
+        assert ctx.branch == "feature/user-auth_v2"
+
+    def test_frozen_dataclass(self) -> None:
+        """Test that RunContext is immutable."""
+        ctx = RunContext(folder="backend", branch="main")
+        with pytest.raises(AttributeError):
+            ctx.folder = "frontend"  # type: ignore
+
+
+class TestResolveRunPath:
+    """Tests for resolve_run_path function."""
+
+    def test_without_branch(self, tmp_path: Path) -> None:
+        """Test resolve_run_path returns folder path when no branch."""
+        result = resolve_run_path(tmp_path, "backend", None)
+        assert result == tmp_path / "backend"
+
+    def test_with_simple_branch(self, tmp_path: Path) -> None:
+        """Test resolve_run_path with simple branch name."""
+        result = resolve_run_path(tmp_path, "backend", "feature-foo")
+        expected = tmp_path / "backend" / ".worktrees" / "feature-foo"
+        assert result == expected
+
+    def test_with_slash_branch(self, tmp_path: Path) -> None:
+        """Test resolve_run_path converts branch slashes to double underscores."""
+        result = resolve_run_path(tmp_path, "backend", "feature/foo")
+        expected = tmp_path / "backend" / ".worktrees" / "feature__foo"
+        assert result == expected
+
+    def test_custom_worktrees_dir(self, tmp_path: Path) -> None:
+        """Test resolve_run_path with custom worktrees directory."""
+        result = resolve_run_path(
+            tmp_path, "backend", "feature-foo", worktrees_dir=".wt"
+        )
+        expected = tmp_path / "backend" / ".wt" / "feature-foo"
+        assert result == expected
+
+    def test_nested_folder_path(self, tmp_path: Path) -> None:
+        """Test resolve_run_path with nested folder path."""
+        result = resolve_run_path(tmp_path, "repos/backend", "main")
+        expected = tmp_path / "repos/backend" / ".worktrees" / "main"
+        assert result == expected

--- a/tests/test_worktrees.py
+++ b/tests/test_worktrees.py
@@ -1,0 +1,283 @@
+"""Tests for pochi.worktrees module."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from pochi.worktrees import (
+    DEFAULT_WORKTREES_DIR,
+    WorktreeError,
+    ensure_worktree,
+    get_active_worktrees,
+    get_worktree_path,
+    sanitize_branch_name,
+)
+
+
+class TestSanitizeBranchName:
+    """Tests for sanitize_branch_name function."""
+
+    def test_simple_name_unchanged(self) -> None:
+        """Test that a simple valid name is unchanged."""
+        assert sanitize_branch_name("feature-foo") == "feature-foo"
+
+    def test_name_with_slash(self) -> None:
+        """Test that names with slashes are preserved."""
+        assert sanitize_branch_name("feature/new-thing") == "feature/new-thing"
+
+    def test_strips_whitespace(self) -> None:
+        """Test that leading/trailing whitespace is stripped."""
+        assert sanitize_branch_name("  branch-name  ") == "branch-name"
+
+    def test_replaces_spaces_with_hyphens(self) -> None:
+        """Test that spaces are replaced with hyphens."""
+        assert sanitize_branch_name("my new branch") == "my-new-branch"
+
+    def test_removes_leading_slashes(self) -> None:
+        """Test that leading slashes are removed."""
+        assert sanitize_branch_name("/feature/foo") == "feature/foo"
+
+    def test_removes_double_dots(self) -> None:
+        """Test that .. sequences are collapsed."""
+        assert sanitize_branch_name("foo..bar") == "foo.bar"
+
+    def test_collapses_double_slashes(self) -> None:
+        """Test that // sequences are collapsed."""
+        assert sanitize_branch_name("foo//bar") == "foo/bar"
+
+    def test_collapses_double_hyphens(self) -> None:
+        """Test that -- sequences are collapsed."""
+        assert sanitize_branch_name("foo--bar") == "foo-bar"
+
+    def test_removes_trailing_slash(self) -> None:
+        """Test that trailing slashes are removed."""
+        assert sanitize_branch_name("feature/foo/") == "feature/foo"
+
+    def test_removes_trailing_dot(self) -> None:
+        """Test that trailing dots are removed."""
+        assert sanitize_branch_name("feature.") == "feature"
+
+    def test_empty_string_raises(self) -> None:
+        """Test that empty string raises ValueError."""
+        with pytest.raises(ValueError, match="cannot be empty"):
+            sanitize_branch_name("")
+
+    def test_whitespace_only_raises(self) -> None:
+        """Test that whitespace-only string raises ValueError."""
+        with pytest.raises(ValueError, match="cannot be empty"):
+            sanitize_branch_name("   ")
+
+    def test_invalid_characters_raise(self) -> None:
+        """Test that invalid characters raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid branch name"):
+            sanitize_branch_name("foo$bar")
+
+    def test_name_with_underscore(self) -> None:
+        """Test that underscores are allowed."""
+        assert sanitize_branch_name("feature_foo") == "feature_foo"
+
+    def test_complex_name(self) -> None:
+        """Test a complex but valid branch name."""
+        assert (
+            sanitize_branch_name("feature/foo-bar_123.test")
+            == "feature/foo-bar_123.test"
+        )
+
+
+class TestGetWorktreePath:
+    """Tests for get_worktree_path function."""
+
+    def test_simple_branch(self, tmp_path: Path) -> None:
+        """Test path for simple branch name."""
+        result = get_worktree_path(tmp_path, "feature-foo")
+        expected = tmp_path / DEFAULT_WORKTREES_DIR / "feature-foo"
+        assert result == expected
+
+    def test_branch_with_slash(self, tmp_path: Path) -> None:
+        """Test path for branch with slash (converted to double underscore)."""
+        result = get_worktree_path(tmp_path, "feature/foo")
+        expected = tmp_path / DEFAULT_WORKTREES_DIR / "feature__foo"
+        assert result == expected
+
+    def test_custom_worktrees_dir(self, tmp_path: Path) -> None:
+        """Test path with custom worktrees directory."""
+        result = get_worktree_path(tmp_path, "feature-foo", worktrees_dir=".wt")
+        expected = tmp_path / ".wt" / "feature-foo"
+        assert result == expected
+
+    def test_nested_slash_branch(self, tmp_path: Path) -> None:
+        """Test path for branch with multiple slashes."""
+        result = get_worktree_path(tmp_path, "feature/user/auth")
+        expected = tmp_path / DEFAULT_WORKTREES_DIR / "feature__user__auth"
+        assert result == expected
+
+
+class TestEnsureWorktree:
+    """Tests for ensure_worktree function."""
+
+    @pytest.fixture
+    def git_repo(self, tmp_path: Path) -> Path:
+        """Create a minimal git repository for testing."""
+        repo_path = tmp_path / "test-repo"
+        repo_path.mkdir()
+
+        # Initialize git repo
+        subprocess.run(
+            ["git", "init"],
+            cwd=repo_path,
+            capture_output=True,
+            check=True,
+        )
+
+        # Configure git user
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=repo_path,
+            check=True,
+        )
+
+        # Create initial commit
+        (repo_path / "README.md").write_text("# Test\n")
+        subprocess.run(["git", "add", "."], cwd=repo_path, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Initial commit"],
+            cwd=repo_path,
+            check=True,
+        )
+
+        return repo_path
+
+    def test_raises_if_not_git_repo(self, tmp_path: Path) -> None:
+        """Test that non-git directory raises WorktreeError."""
+        non_repo = tmp_path / "not-a-repo"
+        non_repo.mkdir()
+
+        with pytest.raises(WorktreeError, match="Not a git repository"):
+            ensure_worktree(non_repo, "feature-foo")
+
+    def test_creates_new_branch_worktree(self, git_repo: Path) -> None:
+        """Test creating worktree for new branch."""
+        result = ensure_worktree(git_repo, "feature-new")
+
+        assert result.exists()
+        assert result == git_repo / DEFAULT_WORKTREES_DIR / "feature-new"
+        assert (result / "README.md").exists()
+
+    def test_reuses_existing_worktree(self, git_repo: Path) -> None:
+        """Test that existing worktree is reused."""
+        # Create worktree first time
+        result1 = ensure_worktree(git_repo, "feature-reuse")
+        assert result1.exists()
+
+        # Create file in worktree
+        marker = result1 / "marker.txt"
+        marker.write_text("test")
+
+        # Second call should reuse
+        result2 = ensure_worktree(git_repo, "feature-reuse")
+        assert result2 == result1
+        assert marker.exists()
+
+    def test_creates_worktree_for_existing_branch(self, git_repo: Path) -> None:
+        """Test creating worktree for existing local branch."""
+        # Create branch first
+        subprocess.run(
+            ["git", "branch", "existing-branch"],
+            cwd=git_repo,
+            check=True,
+        )
+
+        result = ensure_worktree(git_repo, "existing-branch")
+        assert result.exists()
+        assert (result / "README.md").exists()
+
+    def test_creates_parent_directories(self, git_repo: Path) -> None:
+        """Test that parent worktrees directory is created."""
+        worktrees_dir = git_repo / DEFAULT_WORKTREES_DIR
+        assert not worktrees_dir.exists()
+
+        ensure_worktree(git_repo, "feature-test")
+        assert worktrees_dir.exists()
+
+    def test_custom_worktrees_dir(self, git_repo: Path) -> None:
+        """Test using custom worktrees directory."""
+        result = ensure_worktree(git_repo, "feature-custom", worktrees_dir=".custom")
+
+        expected = git_repo / ".custom" / "feature-custom"
+        assert result == expected
+        assert result.exists()
+
+
+class TestGetActiveWorktrees:
+    """Tests for get_active_worktrees function."""
+
+    @pytest.fixture
+    def git_repo_with_worktrees(self, tmp_path: Path) -> Path:
+        """Create a git repo with some worktrees."""
+        repo_path = tmp_path / "test-repo"
+        repo_path.mkdir()
+
+        # Initialize git repo
+        subprocess.run(["git", "init"], cwd=repo_path, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=repo_path,
+            check=True,
+        )
+        (repo_path / "README.md").write_text("# Test\n")
+        subprocess.run(["git", "add", "."], cwd=repo_path, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Initial commit"], cwd=repo_path, check=True
+        )
+
+        # Create worktrees
+        ensure_worktree(repo_path, "feature-one")
+        ensure_worktree(repo_path, "feature-two")
+
+        return repo_path
+
+    def test_returns_empty_for_no_worktrees(self, tmp_path: Path) -> None:
+        """Test returns empty list when no worktrees exist."""
+        repo_path = tmp_path / "empty-repo"
+        repo_path.mkdir()
+        subprocess.run(["git", "init"], cwd=repo_path, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=repo_path,
+            check=True,
+        )
+        (repo_path / "README.md").write_text("# Test\n")
+        subprocess.run(["git", "add", "."], cwd=repo_path, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Initial commit"], cwd=repo_path, check=True
+        )
+
+        result = get_active_worktrees(repo_path)
+        assert result == []
+
+    def test_returns_active_worktrees(self, git_repo_with_worktrees: Path) -> None:
+        """Test returns list of active worktrees."""
+        result = get_active_worktrees(git_repo_with_worktrees)
+
+        assert len(result) == 2
+        branches = [branch for branch, _ in result]
+        assert "feature-one" in branches
+        assert "feature-two" in branches


### PR DESCRIPTION
## Summary

- Add opt-in git worktree support via `@branch` directive
- When a user specifies `@branch` in their message, Pochi creates/reuses a worktree and runs the agent there
- Context is preserved via `ctx: folder @ branch` footer, allowing replies to continue in the same worktree

## Changes

**New modules:**
- `src/pochi/utils/git.py` - Git command helpers (run_git, branch_exists, list_worktrees, etc.)
- `src/pochi/worktrees.py` - Worktree creation/management (ensure_worktree, sanitize_branch_name)
- `src/pochi/context.py` - RunContext dataclass for tracking folder/branch state

**Modified:**
- `src/pochi/settings.py` & `src/pochi/config.py` - Added `worktrees_dir` and `worktree_base` config options
- `src/pochi/workspace/router.py` - Added `parse_branch_directive()` and context extraction from replies
- `src/pochi/workspace/bridge.py` - Worktree creation logic and context passing to renderer
- `src/pochi/render.py` - Footer rendering includes context when using worktrees

## Usage

```
@feat/new-feature implement the thing
```

Or combined with engine directive:
```
/claude @fix/bug123 debug the crash
```

## Configuration

```toml
# .pochi/workspace.toml
[workspace]
worktrees_dir = ".worktrees"  # Optional, default ".worktrees"
worktree_base = "main"        # Optional, base for new branches
```

## Test plan

- [x] Unit tests for branch name sanitization
- [x] Unit tests for worktree path calculation
- [x] Integration tests for worktree creation (using real git repos)
- [x] Unit tests for @branch directive parsing
- [x] Unit tests for context extraction from reply messages
- [x] Unit tests for RunContext formatting and parsing
- [x] All 615 tests pass

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)