### PR TITLE
feat: Plugin system and public API (closes #17)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,17 @@ Issues = "https://github.com/asianviking/pochi/issues"
 [project.scripts]
 pochi = "pochi.cli:main"
 
+# Plugin entrypoints for built-in backends
+# Note: mock runner is internal-only (for testing) - no entrypoint
+[project.entry-points."pochi.engine_backends"]
+claude = "pochi.runners.claude:BACKEND"
+codex = "pochi.runners.codex:BACKEND"
+opencode = "pochi.runners.opencode:BACKEND"
+pi = "pochi.runners.pi:BACKEND"
+
+[project.entry-points."pochi.transport_backends"]
+telegram = "pochi.transports.telegram:BACKEND"
+
 [build-system]
 requires = ["uv_build>=0.9.18,<0.10.0"]
 build-backend = "uv_build"

--- a/src/pochi/api.py
+++ b/src/pochi/api.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 from .backends import (
     EngineBackend,
     EngineConfig,
-    SetupIssue,
 )
 from .command_backend import (
     CommandBackend,
@@ -67,6 +66,7 @@ from .settings import ConfigError
 
 # --- Transport backends ---
 from .transport_backend import (
+    SetupIssue,
     SetupResult,
     TransportBackend,
 )

--- a/src/pochi/api.py
+++ b/src/pochi/api.py
@@ -1,0 +1,127 @@
+"""Public Plugin API for Pochi.
+
+This module exports the stable API surface for plugin authors.
+Anything not imported from `pochi.api` should be considered internal
+and subject to change.
+
+Plugin authors should pin to a compatible Pochi version range:
+    dependencies = ["pochi>=0.2,<0.3"]
+
+Example plugin usage:
+    from pochi.api import (
+        EngineBackend,
+        EngineConfig,
+        CommandBackend,
+        CommandContext,
+        CommandResult,
+    )
+"""
+
+from __future__ import annotations
+
+# --- Engine backends and runners ---
+from .backends import (
+    EngineBackend,
+    EngineConfig,
+    SetupIssue,
+)
+from .command_backend import (
+    CommandBackend,
+    CommandContext,
+    CommandExecutor,
+    CommandResult,
+    RunMode,
+    RunRequest,
+    RunResult,
+)
+from .events import EventFactory
+from .model import (
+    Action,
+    ActionEvent,
+    ActionKind,
+    ActionLevel,
+    ActionPhase,
+    CompletedEvent,
+    EngineId,
+    PochiEvent,
+    ResumeToken,
+    StartedEvent,
+)
+
+# --- Router ---
+from .router import (
+    RunnerEntry,
+    RunnerUnavailableError,
+)
+from .runner import (
+    BaseRunner,
+    JsonlRunState,
+    JsonlSubprocessRunner,
+    ResumeTokenMixin,
+    Runner,
+    SessionLockMixin,
+)
+
+# --- Configuration ---
+from .settings import ConfigError
+
+# --- Transport backends ---
+from .transport_backend import (
+    SetupResult,
+    TransportBackend,
+)
+from .transport_runtime import (
+    ResolvedMessage,
+    ResolvedRunner,
+    TransportRuntime,
+)
+
+# API version for compatibility tracking
+POCHI_PLUGIN_API_VERSION = 1
+
+# --- Exports ---
+
+__all__ = [
+    # Version
+    "POCHI_PLUGIN_API_VERSION",
+    # Engine types
+    "EngineBackend",
+    "EngineConfig",
+    "EngineId",
+    "Runner",
+    "BaseRunner",
+    "JsonlSubprocessRunner",
+    "JsonlRunState",
+    "ResumeTokenMixin",
+    "SessionLockMixin",
+    "RunnerEntry",
+    "RunnerUnavailableError",
+    # Event types
+    "PochiEvent",
+    "StartedEvent",
+    "ActionEvent",
+    "CompletedEvent",
+    "Action",
+    "ActionKind",
+    "ActionPhase",
+    "ActionLevel",
+    "EventFactory",
+    "ResumeToken",
+    # Transport types
+    "TransportBackend",
+    "TransportRuntime",
+    "SetupResult",
+    "SetupIssue",
+    "ResolvedMessage",
+    "ResolvedRunner",
+    # Command types
+    "CommandBackend",
+    "CommandContext",
+    "CommandExecutor",
+    "CommandResult",
+    "RunRequest",
+    "RunResult",
+    "RunMode",
+    # Config types
+    "ConfigError",
+]

--- a/src/pochi/command_backend.py
+++ b/src/pochi/command_backend.py
@@ -1,0 +1,230 @@
+"""Command backend protocol for custom /command plugins.
+
+Command backends add custom slash command handlers to Pochi workspaces.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
+    from .model import EngineId, ResumeToken
+    from .transport_runtime import TransportRuntime
+
+
+@dataclass(frozen=True, slots=True)
+class CommandResult:
+    """Result returned by a command handler.
+
+    This is a simple response payload. For more complex responses,
+    use the executor to send multiple messages or run engines.
+    """
+
+    text: str
+    parse_mode: Literal["text", "markdown", "html"] = "text"
+
+
+@dataclass(frozen=True, slots=True)
+class RunRequest:
+    """Request to run an engine via CommandExecutor."""
+
+    prompt: str
+    engine: str | None = None  # None = use default engine
+    resume: "ResumeToken | None" = None
+
+
+@dataclass(slots=True)
+class RunResult:
+    """Result of running an engine via CommandExecutor."""
+
+    engine: "EngineId"
+    ok: bool
+    answer: str
+    resume: "ResumeToken | None" = None
+    error: str | None = None
+
+
+RunMode = Literal["emit", "capture"]
+
+
+class CommandExecutor(Protocol):
+    """Executor for running engines and sending messages from command handlers.
+
+    This provides a safe interface for command plugins to:
+    - Send messages to the chat
+    - Run engine prompts and capture or emit results
+    """
+
+    async def send_message(
+        self,
+        text: str,
+        *,
+        parse_mode: Literal["text", "markdown", "html"] = "text",
+        reply_to: int | None = None,
+    ) -> int | None:
+        """Send a message to the current channel.
+
+        Args:
+            text: Message text
+            parse_mode: How to parse the text
+            reply_to: Message ID to reply to
+
+        Returns:
+            The sent message ID, or None if sending failed
+        """
+        ...
+
+    async def run_one(
+        self,
+        request: RunRequest,
+        *,
+        mode: RunMode = "emit",
+    ) -> RunResult:
+        """Run a single engine request.
+
+        Args:
+            request: The run request with prompt and optional engine/resume
+            mode: "emit" sends progress/result to chat, "capture" collects silently
+
+        Returns:
+            RunResult with the engine output
+        """
+        ...
+
+    async def run_many(
+        self,
+        requests: list[RunRequest],
+        *,
+        mode: RunMode = "emit",
+        parallel: bool = False,
+    ) -> list[RunResult]:
+        """Run multiple engine requests.
+
+        Args:
+            requests: List of run requests
+            mode: "emit" sends progress/result to chat, "capture" collects silently
+            parallel: If True, run requests concurrently
+
+        Returns:
+            List of RunResults in same order as requests
+        """
+        ...
+
+
+@dataclass(slots=True)
+class CommandContext:
+    """Context passed to a command handler.
+
+    Provides access to:
+    - The raw command text and parsed arguments
+    - The original message and reply metadata
+    - Plugin-specific configuration
+    - Runtime for engine/folder resolution
+    - Executor for sending messages or running engines
+    """
+
+    # The command name (without /)
+    command: str
+
+    # Arguments after the command (stripped)
+    args_text: str
+
+    # The full original message text
+    raw_text: str
+
+    # Message metadata
+    message_id: int
+    reply_to_message_id: int | None = None
+    reply_to_text: str | None = None
+
+    # Channel/chat info
+    channel_id: str | None = None
+    thread_id: int | None = None
+
+    # Config path (if available)
+    config_path: Path | None = None
+
+    # Plugin-specific config from [plugins.<id>]
+    plugin_config: dict[str, Any] = field(default_factory=dict)
+
+    # Runtime for engine/folder resolution
+    runtime: "TransportRuntime | None" = None
+
+    # Executor for sending messages and running engines
+    executor: "CommandExecutor | None" = None
+
+
+class CommandBackend(Protocol):
+    """Protocol for command backend plugins.
+
+    Command backends add custom /command handlers. Commands only run when:
+    - The message starts with /<command_id>
+    - The command ID doesn't conflict with engine IDs, folder aliases, or reserved IDs
+
+    Example implementation:
+
+        class MultiCommand:
+            id = "multi"
+            description = "Run the prompt on every available engine"
+
+            async def handle(self, ctx: CommandContext) -> CommandResult | None:
+                prompt = ctx.args_text.strip()
+                if not prompt:
+                    return CommandResult(text="Usage: /multi <prompt>")
+
+                # Get available engines from runtime
+                engines = ctx.runtime.available_engine_ids()
+
+                # Run on each engine
+                requests = [
+                    RunRequest(prompt=prompt, engine=engine)
+                    for engine in engines
+                ]
+                results = await ctx.executor.run_many(
+                    requests, mode="capture", parallel=True
+                )
+
+                # Format response
+                blocks = []
+                for result in results:
+                    text = result.answer if result.ok else f"Error: {result.error}"
+                    blocks.append(f"## {result.engine}\\n{text}")
+
+                return CommandResult(text="\\n\\n".join(blocks), parse_mode="markdown")
+
+        BACKEND = MultiCommand()
+
+    Plugin configuration is available in ctx.plugin_config from workspace.toml:
+
+        [plugins.multi]
+        engines = ["claude", "codex"]
+    """
+
+    @property
+    def id(self) -> str:
+        """The command name (without /). Must match ID pattern."""
+        ...
+
+    @property
+    def description(self) -> str:
+        """Human-readable description shown in /help."""
+        ...
+
+    def handle(
+        self,
+        ctx: CommandContext,
+    ) -> "Awaitable[CommandResult | None]":
+        """Handle a command invocation.
+
+        Args:
+            ctx: The command context with message info and runtime access
+
+        Returns:
+            CommandResult with response text, or None to indicate no response.
+            For complex responses, use ctx.executor to send multiple messages.
+        """
+        ...

--- a/src/pochi/config.py
+++ b/src/pochi/config.py
@@ -93,6 +93,12 @@ class WorkspaceConfig:
     ralph: RalphConfig = field(default_factory=RalphConfig)
     default_engine: str = "claude"
 
+    # Worktree settings
+    worktrees_dir: str = ".worktrees"  # Directory name for worktrees within folders
+    worktree_base: str | None = (
+        None  # Base branch for new worktrees (auto-detect if None)
+    )
+
     # Transport configs
     telegram: TelegramConfig | None = None
 
@@ -168,6 +174,8 @@ def _settings_to_config(settings: WorkspaceSettings, root: Path) -> WorkspaceCon
         folders=folders,
         ralph=ralph,
         default_engine=settings.default_engine,
+        worktrees_dir=settings.worktrees_dir,
+        worktree_base=settings.worktree_base,
         telegram=telegram,
         telegram_group_id=telegram_group_id,
         bot_token=bot_token,
@@ -209,6 +217,10 @@ def save_workspace_config(config: WorkspaceConfig) -> None:
     workspace.add("name", config.name)
     if config.default_engine != "claude":
         workspace.add("default_engine", config.default_engine)
+    if config.worktrees_dir != ".worktrees":
+        workspace.add("worktrees_dir", config.worktrees_dir)
+    if config.worktree_base:
+        workspace.add("worktree_base", config.worktree_base)
     doc.add("workspace", workspace)
 
     # [telegram] section (new format)

--- a/src/pochi/config.py
+++ b/src/pochi/config.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 import tomlkit
 
@@ -31,6 +32,7 @@ logger = get_logger(__name__)
 __all__ = [
     "ConfigError",
     "FolderConfig",
+    "PluginsConfig",
     "RalphConfig",
     "TelegramConfig",
     "WorkspaceConfig",
@@ -43,6 +45,17 @@ __all__ = [
     "WORKSPACE_CONFIG_DIR",
     "WORKSPACE_CONFIG_FILE",
 ]
+
+
+@dataclass
+class PluginsConfig:
+    """Plugin configuration."""
+
+    # List of distribution names to enable. Empty = load all.
+    enabled: list[str] = field(default_factory=list)
+
+    # Reserved for future use - not implemented
+    auto_install: bool = False
 
 
 @dataclass
@@ -102,6 +115,10 @@ class WorkspaceConfig:
     # Transport configs
     telegram: TelegramConfig | None = None
 
+    # Plugin configuration
+    plugins: PluginsConfig = field(default_factory=PluginsConfig)
+    plugin_configs: dict[str, dict[str, Any]] = field(default_factory=dict)
+
     # Legacy fields for backwards compatibility
     telegram_group_id: int = 0
     bot_token: str = ""
@@ -158,6 +175,12 @@ def _settings_to_config(settings: WorkspaceSettings, root: Path) -> WorkspaceCon
             chat_id=settings.telegram.chat_id,
         )
 
+    # Convert plugins
+    plugins = PluginsConfig(
+        enabled=settings.plugins.enabled,
+        auto_install=settings.plugins.auto_install,
+    )
+
     # Get legacy fields (for backward compatibility)
     bot_token = ""
     telegram_group_id = 0
@@ -177,6 +200,8 @@ def _settings_to_config(settings: WorkspaceSettings, root: Path) -> WorkspaceCon
         worktrees_dir=settings.worktrees_dir,
         worktree_base=settings.worktree_base,
         telegram=telegram,
+        plugins=plugins,
+        plugin_configs=settings.plugin_configs,
         telegram_group_id=telegram_group_id,
         bot_token=bot_token,
     )

--- a/src/pochi/context.py
+++ b/src/pochi/context.py
@@ -1,0 +1,82 @@
+"""Run context for tracking folder and branch state during execution."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class RunContext:
+    """Context for a single agent run, tracking folder and optional branch.
+
+    This context is included in message footers and used to route replies
+    back to the correct worktree.
+    """
+
+    folder: str
+    branch: str | None = None
+
+    def format_footer(self) -> str:
+        """Format the context as a footer line for messages.
+
+        Returns:
+            A string like "`ctx: folder @ branch`" or "`ctx: folder`".
+        """
+        if self.branch:
+            return f"`ctx: {self.folder} @ {self.branch}`"
+        return f"`ctx: {self.folder}`"
+
+    @classmethod
+    def parse(cls, text: str) -> "RunContext | None":
+        """Parse a RunContext from message text containing a ctx: footer.
+
+        Args:
+            text: Message text that may contain a ctx: footer.
+
+        Returns:
+            RunContext if found, None otherwise.
+        """
+        # Look for `ctx: folder @ branch` or `ctx: folder`
+        # Match backtick-wrapped format
+        pattern = r"`ctx:\s*([^@`]+?)(?:\s*@\s*([^`]+))?`"
+        match = re.search(pattern, text)
+        if not match:
+            return None
+
+        folder = match.group(1).strip()
+        branch = match.group(2).strip() if match.group(2) else None
+
+        if not folder:
+            return None
+
+        return cls(folder=folder, branch=branch)
+
+
+def resolve_run_path(
+    workspace_root: Path,
+    folder_path: str,
+    branch: str | None,
+    *,
+    worktrees_dir: str = ".worktrees",
+) -> Path:
+    """Resolve the actual working directory for a run.
+
+    Args:
+        workspace_root: Absolute path to workspace root.
+        folder_path: Relative path to the folder from workspace root.
+        branch: Branch name (if using worktree), or None for main checkout.
+        worktrees_dir: Directory name for worktrees.
+
+    Returns:
+        Absolute path to use as working directory.
+    """
+    folder_abs = workspace_root / folder_path
+
+    if branch is None:
+        return folder_abs
+
+    # Convert branch slashes to double underscores for filesystem
+    safe_branch = branch.replace("/", "__")
+    return folder_abs / worktrees_dir / safe_branch

--- a/src/pochi/ids.py
+++ b/src/pochi/ids.py
@@ -1,0 +1,112 @@
+"""Plugin ID validation and reserved ID management.
+
+Plugin IDs are used in the CLI and in Telegram commands.
+They must match the ID pattern and not conflict with reserved IDs.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+# Plugin ID must be lowercase alphanumeric with underscores, 1-32 chars
+ID_PATTERN = re.compile(r"^[a-z0-9_]{1,32}$")
+
+PluginKind = Literal["engine", "transport", "command"]
+
+# Reserved IDs for engines - these cannot be used as engine plugin IDs
+# because they conflict with core commands or CLI commands
+RESERVED_ENGINE_IDS: frozenset[str] = frozenset(
+    {
+        "cancel",  # Core chat command
+        "help",  # Core chat command
+        "init",  # CLI command
+        "plugins",  # CLI command
+        "info",  # CLI command
+        "setup",  # CLI command
+    }
+)
+
+# Reserved IDs for commands - these cannot be used as command plugin IDs
+# because they conflict with built-in workspace commands
+RESERVED_COMMAND_IDS: frozenset[str] = frozenset(
+    {
+        # Core commands
+        "cancel",
+        "help",
+        # Workspace management commands
+        "clone",
+        "create",
+        "add",
+        "list",
+        "remove",
+        "status",
+        "engine",
+        # Worker topic commands
+        "ralph",
+    }
+)
+
+# Reserved IDs for transports - currently none, but structure exists
+RESERVED_TRANSPORT_IDS: frozenset[str] = frozenset()
+
+
+def is_valid_id(plugin_id: str) -> bool:
+    """Check if a plugin ID matches the required pattern.
+
+    IDs must be 1-32 lowercase alphanumeric characters or underscores.
+    """
+    return bool(ID_PATTERN.match(plugin_id))
+
+
+def is_reserved_id(plugin_id: str, kind: PluginKind) -> bool:
+    """Check if a plugin ID is reserved for a given plugin kind."""
+    if kind == "engine":
+        return plugin_id in RESERVED_ENGINE_IDS
+    if kind == "transport":
+        return plugin_id in RESERVED_TRANSPORT_IDS
+    if kind == "command":
+        return plugin_id in RESERVED_COMMAND_IDS
+    return False
+
+
+def validate_plugin_id(
+    plugin_id: str,
+    kind: PluginKind,
+    *,
+    context: str = "",
+) -> tuple[bool, str | None]:
+    """Validate a plugin ID for a given kind.
+
+    Args:
+        plugin_id: The ID to validate
+        kind: The plugin kind (engine, transport, command)
+        context: Optional context string for error messages (e.g., entrypoint name)
+
+    Returns:
+        Tuple of (is_valid, error_message).
+        If valid, error_message is None.
+    """
+    ctx = f" ({context})" if context else ""
+
+    if not is_valid_id(plugin_id):
+        return False, (
+            f"Invalid {kind} ID '{plugin_id}'{ctx}: "
+            f"must match pattern {ID_PATTERN.pattern}"
+        )
+
+    if is_reserved_id(plugin_id, kind):
+        return False, f"Reserved {kind} ID '{plugin_id}'{ctx}: conflicts with built-in"
+
+    return True, None
+
+
+def get_reserved_ids(kind: PluginKind) -> frozenset[str]:
+    """Get the set of reserved IDs for a given plugin kind."""
+    if kind == "engine":
+        return RESERVED_ENGINE_IDS
+    if kind == "transport":
+        return RESERVED_TRANSPORT_IDS
+    if kind == "command":
+        return RESERVED_COMMAND_IDS
+    return frozenset()

--- a/src/pochi/plugins.py
+++ b/src/pochi/plugins.py
@@ -1,0 +1,355 @@
+"""Plugin discovery via Python entrypoints.
+
+Pochi supports three types of plugins:
+- Engine backends (pochi.engine_backends): New AI engine runners
+- Transport backends (pochi.transport_backends): New messaging platforms
+- Command backends (pochi.command_backends): Custom /command handlers
+
+Plugins are discovered lazily: IDs are listed without importing until needed.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from functools import cache
+from typing import TYPE_CHECKING, Any, Literal
+
+from .ids import PluginKind, validate_plugin_id
+from .logging import get_logger
+
+if TYPE_CHECKING:
+    from importlib.metadata import EntryPoint
+
+    from .backends import EngineBackend
+    from .command_backend import CommandBackend
+    from .transport_backend import TransportBackend
+
+logger = get_logger(__name__)
+
+# Entrypoint group names
+ENGINE_BACKENDS_GROUP = "pochi.engine_backends"
+TRANSPORT_BACKENDS_GROUP = "pochi.transport_backends"
+COMMAND_BACKENDS_GROUP = "pochi.command_backends"
+
+PluginType = Literal["engine", "transport", "command"]
+
+
+@dataclass(frozen=True, slots=True)
+class PluginEntry:
+    """A discovered plugin entrypoint (not yet loaded)."""
+
+    id: str
+    entrypoint: "EntryPoint"
+    kind: PluginKind
+    distribution: str | None = None  # Package name if resolvable
+
+
+@dataclass(slots=True)
+class LoadedPlugin:
+    """A loaded and validated plugin."""
+
+    id: str
+    kind: PluginKind
+    backend: Any  # EngineBackend | TransportBackend | CommandBackend
+    distribution: str | None = None
+    error: str | None = None  # If loading failed
+
+
+@dataclass(slots=True)
+class PluginDiscoveryResult:
+    """Result of plugin discovery for one entrypoint group."""
+
+    kind: PluginKind
+    entries: list[PluginEntry] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class PluginLoadResult:
+    """Result of loading all plugins from discovery."""
+
+    engine_backends: dict[str, "EngineBackend"] = field(default_factory=dict)
+    transport_backends: dict[str, "TransportBackend"] = field(default_factory=dict)
+    command_backends: dict[str, "CommandBackend"] = field(default_factory=dict)
+    errors: list[str] = field(default_factory=list)
+
+
+def _get_distribution_name(entrypoint: "EntryPoint") -> str | None:
+    """Get the distribution (package) name for an entrypoint."""
+    # In Python 3.10+, entry_points have a .dist attribute
+    try:
+        dist = entrypoint.dist
+        if dist is not None:
+            return dist.name
+    except AttributeError:
+        pass
+
+    # Fallback: try to get from group metadata
+    try:
+        return entrypoint.group
+    except AttributeError:
+        pass
+
+    return None
+
+
+def _discover_entrypoints(group: str, kind: PluginKind) -> PluginDiscoveryResult:
+    """Discover plugins from an entrypoint group without loading them."""
+    if sys.version_info >= (3, 10):
+        from importlib.metadata import entry_points
+
+        eps = entry_points(group=group)
+    else:
+        from importlib.metadata import entry_points
+
+        all_eps = entry_points()
+        eps = all_eps.get(group, [])
+
+    result = PluginDiscoveryResult(kind=kind)
+
+    for ep in eps:
+        plugin_id = ep.name
+        dist_name = _get_distribution_name(ep)
+
+        # Validate ID
+        valid, error = validate_plugin_id(plugin_id, kind, context=ep.value)
+        if not valid:
+            result.errors.append(error or f"Invalid ID: {plugin_id}")
+            continue
+
+        entry = PluginEntry(
+            id=plugin_id,
+            entrypoint=ep,
+            kind=kind,
+            distribution=dist_name,
+        )
+        result.entries.append(entry)
+
+    return result
+
+
+def discover_engine_plugins() -> PluginDiscoveryResult:
+    """Discover engine backend plugins without loading them."""
+    return _discover_entrypoints(ENGINE_BACKENDS_GROUP, "engine")
+
+
+def discover_transport_plugins() -> PluginDiscoveryResult:
+    """Discover transport backend plugins without loading them."""
+    return _discover_entrypoints(TRANSPORT_BACKENDS_GROUP, "transport")
+
+
+def discover_command_plugins() -> PluginDiscoveryResult:
+    """Discover command backend plugins without loading them."""
+    return _discover_entrypoints(COMMAND_BACKENDS_GROUP, "command")
+
+
+def discover_all_plugins() -> dict[PluginKind, PluginDiscoveryResult]:
+    """Discover all plugins without loading them."""
+    return {
+        "engine": discover_engine_plugins(),
+        "transport": discover_transport_plugins(),
+        "command": discover_command_plugins(),
+    }
+
+
+def _load_engine_backend(entry: PluginEntry) -> LoadedPlugin:
+    """Load and validate an engine backend plugin."""
+    from .backends import EngineBackend
+
+    try:
+        backend = entry.entrypoint.load()
+    except Exception as exc:
+        return LoadedPlugin(
+            id=entry.id,
+            kind=entry.kind,
+            backend=None,
+            distribution=entry.distribution,
+            error=f"Failed to load: {exc}",
+        )
+
+    if not isinstance(backend, EngineBackend):
+        return LoadedPlugin(
+            id=entry.id,
+            kind=entry.kind,
+            backend=None,
+            distribution=entry.distribution,
+            error=f"Expected EngineBackend, got {type(backend).__name__}",
+        )
+
+    if backend.id != entry.id:
+        return LoadedPlugin(
+            id=entry.id,
+            kind=entry.kind,
+            backend=None,
+            distribution=entry.distribution,
+            error=f"ID mismatch: entrypoint '{entry.id}' != backend.id '{backend.id}'",
+        )
+
+    return LoadedPlugin(
+        id=entry.id,
+        kind=entry.kind,
+        backend=backend,
+        distribution=entry.distribution,
+    )
+
+
+def _load_transport_backend(entry: PluginEntry) -> LoadedPlugin:
+    """Load and validate a transport backend plugin."""
+    try:
+        backend = entry.entrypoint.load()
+    except Exception as exc:
+        return LoadedPlugin(
+            id=entry.id,
+            kind=entry.kind,
+            backend=None,
+            distribution=entry.distribution,
+            error=f"Failed to load: {exc}",
+        )
+
+    # Check if it has the required protocol attributes
+    if not hasattr(backend, "id") or not hasattr(backend, "check_setup"):
+        return LoadedPlugin(
+            id=entry.id,
+            kind=entry.kind,
+            backend=None,
+            distribution=entry.distribution,
+            error="Does not implement TransportBackend protocol",
+        )
+
+    if backend.id != entry.id:
+        return LoadedPlugin(
+            id=entry.id,
+            kind=entry.kind,
+            backend=None,
+            distribution=entry.distribution,
+            error=f"ID mismatch: entrypoint '{entry.id}' != backend.id '{backend.id}'",
+        )
+
+    return LoadedPlugin(
+        id=entry.id,
+        kind=entry.kind,
+        backend=backend,
+        distribution=entry.distribution,
+    )
+
+
+def _load_command_backend(entry: PluginEntry) -> LoadedPlugin:
+    """Load and validate a command backend plugin."""
+    try:
+        backend = entry.entrypoint.load()
+    except Exception as exc:
+        return LoadedPlugin(
+            id=entry.id,
+            kind=entry.kind,
+            backend=None,
+            distribution=entry.distribution,
+            error=f"Failed to load: {exc}",
+        )
+
+    # Check if it has the required protocol attributes
+    if not hasattr(backend, "id") or not hasattr(backend, "handle"):
+        return LoadedPlugin(
+            id=entry.id,
+            kind=entry.kind,
+            backend=None,
+            distribution=entry.distribution,
+            error="Does not implement CommandBackend protocol",
+        )
+
+    if backend.id != entry.id:
+        return LoadedPlugin(
+            id=entry.id,
+            kind=entry.kind,
+            backend=None,
+            distribution=entry.distribution,
+            error=f"ID mismatch: entrypoint '{entry.id}' != backend.id '{backend.id}'",
+        )
+
+    return LoadedPlugin(
+        id=entry.id,
+        kind=entry.kind,
+        backend=backend,
+        distribution=entry.distribution,
+    )
+
+
+def load_plugin(entry: PluginEntry) -> LoadedPlugin:
+    """Load and validate a single plugin."""
+    if entry.kind == "engine":
+        return _load_engine_backend(entry)
+    if entry.kind == "transport":
+        return _load_transport_backend(entry)
+    if entry.kind == "command":
+        return _load_command_backend(entry)
+    return LoadedPlugin(
+        id=entry.id,
+        kind=entry.kind,
+        backend=None,
+        distribution=entry.distribution,
+        error=f"Unknown plugin kind: {entry.kind}",
+    )
+
+
+def load_all_plugins(
+    *,
+    enabled_distributions: set[str] | None = None,
+) -> PluginLoadResult:
+    """Load all discovered plugins.
+
+    Args:
+        enabled_distributions: If set, only load plugins from these distributions.
+            If None or empty, load all plugins.
+
+    Returns:
+        PluginLoadResult with loaded backends and any errors.
+    """
+    result = PluginLoadResult()
+    discovery = discover_all_plugins()
+
+    for kind, disc_result in discovery.items():
+        # Add discovery errors
+        result.errors.extend(disc_result.errors)
+
+        for entry in disc_result.entries:
+            # Check enabled filter
+            if enabled_distributions:
+                dist_lower = (entry.distribution or "").lower()
+                if not any(
+                    dist_lower == enabled.lower() for enabled in enabled_distributions
+                ):
+                    continue
+
+            loaded = load_plugin(entry)
+
+            if loaded.error:
+                result.errors.append(f"{kind}/{loaded.id}: {loaded.error}")
+                continue
+
+            if kind == "engine":
+                result.engine_backends[loaded.id] = loaded.backend
+            elif kind == "transport":
+                result.transport_backends[loaded.id] = loaded.backend
+            elif kind == "command":
+                result.command_backends[loaded.id] = loaded.backend
+
+    return result
+
+
+@cache
+def _cached_engine_backends() -> dict[str, "EngineBackend"]:
+    """Cached loading of engine backends."""
+    result = load_all_plugins()
+    for error in result.errors:
+        logger.warning("plugin.error", error=error)
+    return result.engine_backends
+
+
+def get_engine_backends() -> dict[str, "EngineBackend"]:
+    """Get all loaded engine backends (cached)."""
+    return _cached_engine_backends()
+
+
+def clear_plugin_cache() -> None:
+    """Clear the plugin loading cache (for testing)."""
+    _cached_engine_backends.cache_clear()

--- a/src/pochi/settings.py
+++ b/src/pochi/settings.py
@@ -77,6 +77,12 @@ class WorkspaceSettings(BaseSettings):
     name: str = ""
     default_engine: str = "claude"
 
+    # Worktree settings
+    worktrees_dir: str = ".worktrees"  # Directory name for worktrees within folders
+    worktree_base: str | None = (
+        None  # Base branch for new worktrees (auto-detect if None)
+    )
+
     # Transport config
     telegram: TelegramSettings | None = None
 
@@ -208,6 +214,8 @@ def load_settings(workspace_root: Path | None = None) -> WorkspaceSettings | Non
         settings = WorkspaceSettings(
             name=workspace_data.get("name", workspace_root.name),
             default_engine=workspace_data.get("default_engine", "claude"),
+            worktrees_dir=workspace_data.get("worktrees_dir", ".worktrees"),
+            worktree_base=workspace_data.get("worktree_base"),
             telegram=_parse_telegram(data),
             folders=_parse_folders(data),
             ralph=_parse_ralph(data),

--- a/src/pochi/transport_backend.py
+++ b/src/pochi/transport_backend.py
@@ -1,0 +1,148 @@
+"""Transport backend protocol for messaging platform plugins.
+
+Transport backends connect Pochi to messaging platforms like Telegram, Discord, Slack, etc.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from .backends import EngineBackend
+    from .transport_runtime import TransportRuntime
+
+
+@dataclass(frozen=True, slots=True)
+class SetupIssue:
+    """An issue found during transport setup validation."""
+
+    title: str
+    lines: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class SetupResult:
+    """Result of transport setup validation."""
+
+    issues: tuple[SetupIssue, ...] = field(default_factory=tuple)
+    config_path: Path | None = None
+
+
+class TransportBackend(Protocol):
+    """Protocol for transport backend plugins.
+
+    Transport backends are responsible for:
+    - Validating configuration and onboarding users
+    - Providing a lock token for preventing parallel runs
+    - Starting the transport loop that handles messages
+
+    Example implementation:
+
+        class MyTransportBackend:
+            id = "mytransport"
+            description = "My custom transport"
+
+            def check_setup(self, engine_backend, *, transport_override=None):
+                # Validate config, return issues
+                return SetupResult(issues=[], config_path=Path("config.toml"))
+
+            def interactive_setup(self, *, force=False):
+                # Run interactive setup wizard
+                return True
+
+            def lock_token(self, *, transport_config, config_path):
+                # Return unique identifier for locking
+                return transport_config.get("chat_id")
+
+            def build_and_run(self, *, transport_config, config_path, runtime, ...):
+                # Start the main message loop
+                ...
+
+        BACKEND = MyTransportBackend()
+    """
+
+    @property
+    def id(self) -> str:
+        """Unique identifier for this transport (e.g., 'telegram', 'discord')."""
+        ...
+
+    @property
+    def description(self) -> str:
+        """Human-readable description of the transport."""
+        ...
+
+    def check_setup(
+        self,
+        engine_backend: "EngineBackend",
+        *,
+        transport_override: str | None = None,
+    ) -> SetupResult:
+        """Validate transport configuration.
+
+        Args:
+            engine_backend: The engine backend to use
+            transport_override: Optional transport-specific config override
+
+        Returns:
+            SetupResult with any issues found and the config path
+        """
+        ...
+
+    def interactive_setup(self, *, force: bool) -> bool:
+        """Run interactive setup wizard.
+
+        Args:
+            force: If True, run setup even if config already exists
+
+        Returns:
+            True if setup completed successfully
+        """
+        ...
+
+    def lock_token(
+        self,
+        *,
+        transport_config: dict[str, Any],
+        config_path: Path,
+    ) -> str | None:
+        """Get a unique token for instance locking.
+
+        This prevents multiple Pochi instances from running on the same chat.
+        Return None if locking is not needed.
+
+        Args:
+            transport_config: The transport configuration dict
+            config_path: Path to the config file
+
+        Returns:
+            A unique string identifier, or None for no locking
+        """
+        ...
+
+    def build_and_run(
+        self,
+        *,
+        transport_config: dict[str, Any],
+        config_path: Path,
+        runtime: "TransportRuntime",
+        final_notify: bool,
+        default_engine_override: str | None,
+    ) -> None:
+        """Build the transport and run the main loop.
+
+        This is the main entry point that should:
+        1. Create the transport client
+        2. Connect to the messaging platform
+        3. Handle incoming messages using the runtime
+        4. Run until shutdown
+
+        Args:
+            transport_config: The transport configuration dict
+            config_path: Path to the config file
+            runtime: TransportRuntime facade for engine/folder resolution
+            final_notify: Whether to send final responses as new messages
+            default_engine_override: Optional engine override from CLI
+        """
+        ...

--- a/src/pochi/transport_runtime.py
+++ b/src/pochi/transport_runtime.py
@@ -1,0 +1,242 @@
+"""TransportRuntime facade for transport plugins.
+
+This provides a safe, stable interface for transport plugins to access
+internal Pochi functionality without coupling to implementation details.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from .model import EngineId, ResumeToken
+
+if TYPE_CHECKING:
+    from .router import AutoRouter
+    from .runner import Runner
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedMessage:
+    """Result of resolving a message for processing."""
+
+    # The prompt text (after stripping resume lines)
+    prompt: str
+
+    # Extracted resume token (if any)
+    resume_token: ResumeToken | None = None
+
+    # Engine override specified in message (e.g., @claude)
+    engine_override: EngineId | None = None
+
+    # Context for folder/project routing
+    context: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedRunner:
+    """Result of resolving a runner for execution."""
+
+    engine: EngineId
+    runner: "Runner"
+    available: bool = True
+    issue: str | None = None
+
+
+class TransportRuntime:
+    """Facade exposing safe interfaces to transport plugins.
+
+    This decouples transport implementations from internal router/config details.
+    Transport plugins should use this class to:
+    - Resolve messages to prompts and resume tokens
+    - Select the appropriate engine runner
+    - Access folder/project configuration
+    - Get plugin-specific configuration
+    """
+
+    def __init__(
+        self,
+        *,
+        router: "AutoRouter",
+        config_path: Path | None = None,
+        plugin_configs: dict[str, dict[str, Any]] | None = None,
+        folder_aliases: tuple[str, ...] = (),
+    ) -> None:
+        """Initialize the transport runtime.
+
+        Args:
+            router: The AutoRouter for engine resolution
+            config_path: Path to the workspace config file
+            plugin_configs: Dict of plugin_id -> config dict
+            folder_aliases: Tuple of available folder/project aliases
+        """
+        self._router = router
+        self._config_path = config_path
+        self._plugin_configs = plugin_configs or {}
+        self._folder_aliases = folder_aliases
+
+    @property
+    def config_path(self) -> Path | None:
+        """Get the active config file path (if available)."""
+        return self._config_path
+
+    @property
+    def default_engine(self) -> EngineId:
+        """Get the default engine ID."""
+        return self._router.default_engine
+
+    @property
+    def engine_ids(self) -> tuple[EngineId, ...]:
+        """Get all configured engine IDs (available and unavailable)."""
+        return self._router.engine_ids
+
+    def available_engine_ids(self) -> tuple[EngineId, ...]:
+        """Get engine IDs that are currently available."""
+        return tuple(e.engine for e in self._router.available_entries)
+
+    def missing_engine_ids(self) -> tuple[EngineId, ...]:
+        """Get engine IDs that are configured but unavailable."""
+        available = set(self.available_engine_ids())
+        return tuple(e for e in self.engine_ids if e not in available)
+
+    def folder_aliases(self) -> tuple[str, ...]:
+        """Get available folder/project aliases."""
+        return self._folder_aliases
+
+    def plugin_config(self, plugin_id: str) -> dict[str, Any]:
+        """Get configuration for a plugin from [plugins.<id>] section.
+
+        Args:
+            plugin_id: The plugin ID
+
+        Returns:
+            Config dict, or empty dict if not configured
+        """
+        return self._plugin_configs.get(plugin_id, {})
+
+    def resolve_engine(
+        self,
+        *,
+        engine_override: EngineId | None = None,
+        resume_token: ResumeToken | None = None,
+    ) -> EngineId:
+        """Resolve which engine to use.
+
+        Priority:
+        1. Resume token's engine (for session continuity)
+        2. Explicit engine override
+        3. Default engine
+
+        Args:
+            engine_override: Explicit engine requested
+            resume_token: Resume token from previous message
+
+        Returns:
+            The resolved engine ID
+        """
+        if resume_token is not None:
+            return resume_token.engine
+        if engine_override is not None:
+            return engine_override
+        return self.default_engine
+
+    def resolve_runner(
+        self,
+        *,
+        resume_token: ResumeToken | None = None,
+        engine_override: EngineId | None = None,
+    ) -> ResolvedRunner:
+        """Resolve the runner for a message.
+
+        Args:
+            resume_token: Resume token from previous message
+            engine_override: Explicit engine requested
+
+        Returns:
+            ResolvedRunner with the selected runner and availability info
+        """
+        engine = self.resolve_engine(
+            engine_override=engine_override,
+            resume_token=resume_token,
+        )
+
+        entry = self._router.entry_for_engine(engine)
+        return ResolvedRunner(
+            engine=entry.engine,
+            runner=entry.runner,
+            available=entry.available,
+            issue=entry.issue,
+        )
+
+    def resolve_message(
+        self,
+        text: str,
+        reply_text: str | None = None,
+    ) -> ResolvedMessage:
+        """Resolve a message to a prompt and resume token.
+
+        Args:
+            text: The message text
+            reply_text: Text of the message being replied to (if any)
+
+        Returns:
+            ResolvedMessage with prompt and extracted resume token
+        """
+        # Extract resume token from text or reply
+        resume_token = self._router.resolve_resume(text, reply_text)
+
+        # Strip resume lines from prompt
+        prompt_lines = []
+        for line in text.split("\n"):
+            if not self._router.is_resume_line(line):
+                prompt_lines.append(line)
+        prompt = "\n".join(prompt_lines).strip()
+
+        return ResolvedMessage(
+            prompt=prompt,
+            resume_token=resume_token,
+        )
+
+    def format_resume(self, token: ResumeToken) -> str:
+        """Format a resume token for display.
+
+        Args:
+            token: The resume token
+
+        Returns:
+            Formatted string like `` `claude resume <token>` ``
+        """
+        return self._router.format_resume(token)
+
+    def is_resume_line(self, line: str) -> bool:
+        """Check if a line is a resume token line.
+
+        Used to strip resume lines from prompts.
+
+        Args:
+            line: A single line of text
+
+        Returns:
+            True if the line is a resume token
+        """
+        return self._router.is_resume_line(line)
+
+    def format_context_line(self, context: dict[str, Any]) -> str | None:
+        """Format a context line for the prompt.
+
+        Args:
+            context: Context dict from ResolvedMessage
+
+        Returns:
+            Formatted context line, or None if no context
+        """
+        # Simple implementation - can be extended for project/branch context
+        folder = context.get("folder")
+        branch = context.get("branch")
+
+        if folder and branch:
+            return f"[{folder}@{branch}]"
+        if folder:
+            return f"[{folder}]"
+        return None

--- a/src/pochi/transports/telegram.py
+++ b/src/pochi/transports/telegram.py
@@ -7,23 +7,139 @@ enabling Pochi to send and receive messages via Telegram bots.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
+from ..backends import SetupIssue
+from ..transport_backend import SetupResult as PluginSetupResult
 from ..transport_registry import SetupResult, TransportBackend
 
 if TYPE_CHECKING:
+    from ..backends import EngineBackend
     from ..config import WorkspaceConfig
+    from ..transport_runtime import TransportRuntime
 
 
 @dataclass(frozen=True, slots=True)
 class TelegramTransportBackend:
-    """Telegram transport backend implementation."""
+    """Telegram transport backend implementation.
+
+    This implements both the new TransportBackend protocol (for plugin discovery)
+    and provides legacy compatibility with transport_registry.
+    """
 
     id: str = "telegram"
     description: str = "Telegram bot transport for group chat interaction"
 
+    # --- New plugin-based protocol methods ---
+
+    def check_setup_plugin(
+        self,
+        engine_backend: "EngineBackend",
+        *,
+        transport_override: str | None = None,
+    ) -> PluginSetupResult:
+        """Check if Telegram is properly configured (plugin protocol).
+
+        This is called during startup to validate configuration.
+        """
+        from ..config import load_workspace_config
+
+        _ = engine_backend, transport_override
+
+        config = load_workspace_config()
+        if config is None:
+            return PluginSetupResult(
+                issues=(
+                    SetupIssue(
+                        title="No workspace configuration found",
+                        lines=("Run 'pochi init' or 'pochi setup' to create one.",),
+                    ),
+                ),
+            )
+
+        issues: list[SetupIssue] = []
+
+        # Check for bot token
+        if not config.bot_token and not (
+            config.telegram and config.telegram.bot_token
+        ):
+            issues.append(
+                SetupIssue(
+                    title="Missing bot_token",
+                    lines=("Run 'pochi setup' to configure Telegram bot token.",),
+                )
+            )
+
+        # Check for group ID
+        if not config.telegram_group_id and not (
+            config.telegram and config.telegram.chat_id
+        ):
+            issues.append(
+                SetupIssue(
+                    title="Missing chat_id",
+                    lines=("Run 'pochi setup' to configure Telegram group ID.",),
+                )
+            )
+
+        return PluginSetupResult(
+            issues=tuple(issues),
+            config_path=config.config_path() if config else None,
+        )
+
+    def interactive_setup(self, *, force: bool) -> bool:
+        """Run interactive setup wizard.
+
+        Delegates to the existing onboarding flow.
+        """
+        from ..onboarding import run_onboarding_sync
+
+        _ = force
+        result = run_onboarding_sync(Path.cwd())
+        return result is not None
+
+    def lock_token(
+        self,
+        *,
+        transport_config: dict[str, Any],
+        config_path: Path,
+    ) -> str | None:
+        """Get a unique token for instance locking.
+
+        For Telegram, we use the chat_id to prevent multiple
+        instances running on the same group.
+        """
+        chat_id = transport_config.get("chat_id")
+        if chat_id:
+            return f"telegram:{chat_id}"
+        return None
+
+    def build_and_run(
+        self,
+        *,
+        transport_config: dict[str, Any],
+        config_path: Path,
+        runtime: "TransportRuntime",
+        final_notify: bool,
+        default_engine_override: str | None,
+    ) -> None:
+        """Build the transport and run the main loop.
+
+        This is the main entry point that starts the Telegram bot loop.
+        Currently delegates to the existing workspace bridge implementation.
+        """
+        # The actual implementation is in cli.py's _run_workspace()
+        # This method is for plugin-based transports that manage their own loop.
+        # For now, Telegram uses the legacy path through cli.py
+        raise NotImplementedError(
+            "Telegram transport currently uses legacy startup path. "
+            "Use 'pochi' command instead."
+        )
+
+    # --- Legacy transport_registry protocol methods ---
+
     def check_setup(self, config: "WorkspaceConfig") -> SetupResult:
-        """Check if Telegram is properly configured.
+        """Check if Telegram is properly configured (legacy protocol).
 
         Args:
             config: Workspace configuration
@@ -32,7 +148,9 @@ class TelegramTransportBackend:
             SetupResult indicating whether Telegram is ready
         """
         # Check for bot token
-        if not config.bot_token and not (config.telegram and config.telegram.bot_token):
+        if not config.bot_token and not (
+            config.telegram and config.telegram.bot_token
+        ):
             return SetupResult(
                 ready=False,
                 message="Missing bot_token. Run 'pochi setup' to configure.",
@@ -71,5 +189,11 @@ class TelegramTransportBackend:
         return "telegram"
 
 
-# Export the backend instance for discovery
-TRANSPORT: TransportBackend = TelegramTransportBackend()
+# Create the backend instance
+_backend = TelegramTransportBackend()
+
+# Export for entrypoint discovery (new plugin system)
+BACKEND = _backend
+
+# Legacy export for backward compatibility with transport_registry
+TRANSPORT: TransportBackend = _backend

--- a/src/pochi/transports/telegram.py
+++ b/src/pochi/transports/telegram.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from ..backends import SetupIssue
+from ..transport_backend import SetupIssue as PluginSetupIssue
 from ..transport_backend import SetupResult as PluginSetupResult
 from ..transport_registry import SetupResult, TransportBackend
 
@@ -51,21 +51,19 @@ class TelegramTransportBackend:
         if config is None:
             return PluginSetupResult(
                 issues=(
-                    SetupIssue(
+                    PluginSetupIssue(
                         title="No workspace configuration found",
                         lines=("Run 'pochi init' or 'pochi setup' to create one.",),
                     ),
                 ),
             )
 
-        issues: list[SetupIssue] = []
+        issues: list[PluginSetupIssue] = []
 
         # Check for bot token
-        if not config.bot_token and not (
-            config.telegram and config.telegram.bot_token
-        ):
+        if not config.bot_token and not (config.telegram and config.telegram.bot_token):
             issues.append(
-                SetupIssue(
+                PluginSetupIssue(
                     title="Missing bot_token",
                     lines=("Run 'pochi setup' to configure Telegram bot token.",),
                 )
@@ -76,7 +74,7 @@ class TelegramTransportBackend:
             config.telegram and config.telegram.chat_id
         ):
             issues.append(
-                SetupIssue(
+                PluginSetupIssue(
                     title="Missing chat_id",
                     lines=("Run 'pochi setup' to configure Telegram group ID.",),
                 )
@@ -148,9 +146,7 @@ class TelegramTransportBackend:
             SetupResult indicating whether Telegram is ready
         """
         # Check for bot token
-        if not config.bot_token and not (
-            config.telegram and config.telegram.bot_token
-        ):
+        if not config.bot_token and not (config.telegram and config.telegram.bot_token):
             return SetupResult(
                 ready=False,
                 message="Missing bot_token. Run 'pochi setup' to configure.",

--- a/src/pochi/utils/git.py
+++ b/src/pochi/utils/git.py
@@ -1,0 +1,232 @@
+"""Git utility functions for working with repositories."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from ..logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class GitError(Exception):
+    """Error from a git operation."""
+
+    def __init__(self, message: str, returncode: int = 1, stderr: str = "") -> None:
+        super().__init__(message)
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+def run_git(
+    *args: str,
+    cwd: Path | None = None,
+    timeout: float = 60.0,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Run a git command and return the result.
+
+    Args:
+        *args: Git command arguments (without 'git' prefix).
+        cwd: Working directory for the command.
+        timeout: Command timeout in seconds.
+        check: If True, raise GitError on non-zero exit.
+
+    Returns:
+        CompletedProcess with stdout/stderr.
+
+    Raises:
+        GitError: If check=True and command fails.
+    """
+    cmd = ["git", *args]
+    logger.debug("git.run", cmd=cmd, cwd=str(cwd) if cwd else None)
+
+    result = subprocess.run(
+        cmd,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+    if check and result.returncode != 0:
+        raise GitError(
+            f"git {args[0]} failed: {result.stderr.strip() or result.stdout.strip()}",
+            returncode=result.returncode,
+            stderr=result.stderr,
+        )
+
+    return result
+
+
+def is_git_repo(path: Path) -> bool:
+    """Check if a path is inside a git repository."""
+    git_dir = path / ".git"
+    return git_dir.exists()
+
+
+def get_current_branch(cwd: Path) -> str | None:
+    """Get the current branch name, or None if detached/not a repo."""
+    try:
+        result = run_git("rev-parse", "--abbrev-ref", "HEAD", cwd=cwd)
+        branch = result.stdout.strip()
+        return branch if branch and branch != "HEAD" else None
+    except (GitError, subprocess.TimeoutExpired):
+        return None
+
+
+def get_default_branch(cwd: Path) -> str:
+    """Get the default branch to use as base for new branches.
+
+    Checks in order: origin/HEAD, origin/main, origin/master, current branch.
+    Falls back to "main" if nothing found.
+    """
+    # Try origin/HEAD
+    try:
+        result = run_git(
+            "symbolic-ref", "refs/remotes/origin/HEAD", cwd=cwd, check=False
+        )
+        if result.returncode == 0:
+            ref = result.stdout.strip()
+            # refs/remotes/origin/main -> main
+            if ref.startswith("refs/remotes/origin/"):
+                return ref.split("/")[-1]
+    except subprocess.TimeoutExpired:
+        pass
+
+    # Try common default branches
+    for branch in ("main", "master"):
+        try:
+            result = run_git(
+                "rev-parse", "--verify", f"origin/{branch}", cwd=cwd, check=False
+            )
+            if result.returncode == 0:
+                return branch
+        except subprocess.TimeoutExpired:
+            continue
+
+    # Fall back to current branch
+    current = get_current_branch(cwd)
+    if current:
+        return current
+
+    return "main"
+
+
+def branch_exists(branch: str, cwd: Path) -> bool:
+    """Check if a local branch exists."""
+    result = run_git("rev-parse", "--verify", branch, cwd=cwd, check=False)
+    return result.returncode == 0
+
+
+def remote_branch_exists(branch: str, cwd: Path, remote: str = "origin") -> bool:
+    """Check if a remote branch exists."""
+    result = run_git(
+        "rev-parse", "--verify", f"{remote}/{branch}", cwd=cwd, check=False
+    )
+    return result.returncode == 0
+
+
+def list_worktrees(cwd: Path) -> list[dict[str, str]]:
+    """List all worktrees for a repository.
+
+    Returns:
+        List of dicts with 'path', 'commit', and 'branch' keys.
+    """
+    try:
+        result = run_git("worktree", "list", "--porcelain", cwd=cwd)
+    except GitError:
+        return []
+
+    worktrees: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+
+    for line in result.stdout.splitlines():
+        if not line:
+            if current:
+                worktrees.append(current)
+                current = {}
+            continue
+
+        if line.startswith("worktree "):
+            current["path"] = line[9:]
+        elif line.startswith("HEAD "):
+            current["commit"] = line[5:]
+        elif line.startswith("branch "):
+            # refs/heads/feature/foo -> feature/foo
+            ref = line[7:]
+            if ref.startswith("refs/heads/"):
+                current["branch"] = ref[11:]
+            else:
+                current["branch"] = ref
+        elif line == "detached":
+            current["branch"] = ""
+
+    if current:
+        worktrees.append(current)
+
+    return worktrees
+
+
+def worktree_exists(worktree_path: Path, cwd: Path) -> bool:
+    """Check if a worktree exists at the given path."""
+    worktrees = list_worktrees(cwd)
+    worktree_str = str(worktree_path.resolve())
+    return any(wt.get("path") == worktree_str for wt in worktrees)
+
+
+def add_worktree(
+    worktree_path: Path,
+    branch: str,
+    cwd: Path,
+    *,
+    create_branch: bool = False,
+    base_ref: str | None = None,
+    timeout: float = 120.0,
+) -> None:
+    """Add a new worktree.
+
+    Args:
+        worktree_path: Path where the worktree should be created.
+        branch: Branch name to checkout in the worktree.
+        cwd: Repository root path.
+        create_branch: If True, create the branch with -b flag.
+        base_ref: Base ref for new branch (used with create_branch).
+        timeout: Command timeout in seconds.
+    """
+    args = ["worktree", "add"]
+
+    if create_branch:
+        args.extend(["-b", branch])
+        args.append(str(worktree_path))
+        if base_ref:
+            args.append(base_ref)
+    else:
+        args.append(str(worktree_path))
+        args.append(branch)
+
+    run_git(*args, cwd=cwd, timeout=timeout)
+    logger.info(
+        "git.worktree.added",
+        path=str(worktree_path),
+        branch=branch,
+        created=create_branch,
+    )
+
+
+def remove_worktree(worktree_path: Path, cwd: Path, *, force: bool = False) -> None:
+    """Remove a worktree.
+
+    Args:
+        worktree_path: Path to the worktree to remove.
+        cwd: Repository root path.
+        force: If True, force removal even if dirty.
+    """
+    args = ["worktree", "remove"]
+    if force:
+        args.append("--force")
+    args.append(str(worktree_path))
+
+    run_git(*args, cwd=cwd)
+    logger.info("git.worktree.removed", path=str(worktree_path))

--- a/src/pochi/workspace/commands.py
+++ b/src/pochi/workspace/commands.py
@@ -6,8 +6,10 @@ import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from ..command_backend import CommandBackend, CommandContext
 from ..engines import list_backend_ids
 from ..logging import get_logger
+from ..plugins import discover_command_plugins, load_plugin
 from .config import save_workspace_config
 
 if TYPE_CHECKING:
@@ -15,6 +17,51 @@ if TYPE_CHECKING:
     from .router import RouteResult
 
 logger = get_logger(__name__)
+
+# Cache for loaded command plugins
+_command_plugins: dict[str, CommandBackend] | None = None
+
+
+def _load_command_plugins() -> dict[str, CommandBackend]:
+    """Load and cache command plugins."""
+    global _command_plugins
+    if _command_plugins is not None:
+        return _command_plugins
+
+    _command_plugins = {}
+    discovery = discover_command_plugins()
+
+    for error in discovery.errors:
+        logger.warning("command.plugin.discovery_error", error=error)
+
+    for entry in discovery.entries:
+        loaded = load_plugin(entry)
+        if loaded.error:
+            logger.warning(
+                "command.plugin.load_error",
+                command=entry.id,
+                error=loaded.error,
+            )
+            continue
+
+        _command_plugins[loaded.id] = loaded.backend
+        logger.debug(
+            "command.plugin.loaded",
+            command=loaded.id,
+            distribution=loaded.distribution,
+        )
+
+    return _command_plugins
+
+
+def get_command_plugins() -> dict[str, CommandBackend]:
+    """Get all loaded command plugins."""
+    return _load_command_plugins()
+
+
+def list_plugin_command_ids() -> list[str]:
+    """List all available plugin command IDs."""
+    return list(get_command_plugins().keys())
 
 
 async def handle_slash_command(
@@ -38,21 +85,74 @@ async def handle_slash_command(
     }
 
     handler = handlers.get(command)
-    if handler is None:
-        # Unknown command - let it fall through to orchestrator
+    if handler is not None:
+        try:
+            await handler(manager, args, reply_to_message_id)
+        except Exception as e:
+            logger.exception(
+                "workspace.command.error",
+                command=command,
+                error=str(e),
+            )
+            await manager.send_to_topic(
+                None,  # General topic
+                f"❌ Error executing /{command}: {e}",
+                reply_to_message_id=reply_to_message_id,
+            )
         return
 
-    try:
-        await handler(manager, args, reply_to_message_id)
-    except Exception as e:
-        logger.exception(
-            "workspace.command.error",
-            command=command,
-            error=str(e),
-        )
+    # Check for plugin commands
+    plugins = get_command_plugins()
+    plugin = plugins.get(command)
+    if plugin is not None:
+        try:
+            await _handle_plugin_command(
+                manager, plugin, command, args, reply_to_message_id
+            )
+        except Exception as e:
+            logger.exception(
+                "workspace.command.plugin_error",
+                command=command,
+                error=str(e),
+            )
+            await manager.send_to_topic(
+                None,
+                f"❌ Error executing /{command}: {e}",
+                reply_to_message_id=reply_to_message_id,
+            )
+        return
+
+    # Unknown command - let it fall through to orchestrator
+
+
+async def _handle_plugin_command(
+    manager: "WorkspaceManager",
+    plugin: CommandBackend,
+    command: str,
+    args: str,
+    reply_to_message_id: int,
+) -> None:
+    """Handle a plugin command."""
+    # Build command context
+    ctx = CommandContext(
+        command=command,
+        args_text=args,
+        raw_text=f"/{command} {args}".strip(),
+        message_id=reply_to_message_id,
+        config_path=manager.config.config_path(),
+        plugin_config=manager.config.plugin_configs.get(plugin.id, {}),
+        # Note: runtime and executor would need to be provided for full functionality
+        # For now, plugins can use basic functionality
+    )
+
+    # Call plugin handler
+    result = await plugin.handle(ctx)
+
+    # Send result if returned
+    if result is not None:
         await manager.send_to_topic(
             None,  # General topic
-            f"❌ Error executing /{command}: {e}",
+            result.text,
             reply_to_message_id=reply_to_message_id,
         )
 
@@ -520,45 +620,61 @@ async def _handle_help(
     reply_to_message_id: int,
 ) -> None:
     """Handle /help"""
-    help_text = """📖 Pochi Workspace Commands
+    help_lines = [
+        "📖 Pochi Workspace Commands",
+        "",
+        "General Topic Commands:",
+        "  /clone <name> <git-url> [path]",
+        "    Clone a git repo and create a topic for it",
+        "",
+        "  /create <name> [--no-git]",
+        "    Create a new folder (with git init by default)",
+        "    Use --no-git for non-repo folders like knowledge vaults",
+        "",
+        "  /add <name> <path>",
+        "    Add an existing folder to the workspace",
+        "",
+        "  /list",
+        "    List all folders in the workspace",
+        "",
+        "  /remove <name>",
+        "    Remove a folder from workspace (doesn't delete files)",
+        "",
+        "  /status",
+        "    Show workspace status",
+        "",
+        "  /engine [name]",
+        "    Show or set the default engine (claude, codex, etc.)",
+        "",
+        "  /help",
+        "    Show this help message",
+        "",
+        "Worker Topic Commands:",
+        "  /ralph <prompt> [--max-iterations N]",
+        "    Run an iterative agent loop",
+        "",
+        "  /cancel",
+        "    Cancel the current run or ralph loop",
+    ]
 
-General Topic Commands:
-  /clone <name> <git-url> [path]
-    Clone a git repo and create a topic for it
+    # Add plugin commands if any
+    plugins = get_command_plugins()
+    if plugins:
+        help_lines.append("")
+        help_lines.append("Plugin Commands:")
+        for cmd_id, plugin in sorted(plugins.items()):
+            desc = getattr(plugin, "description", "")
+            if desc:
+                help_lines.append(f"  /{cmd_id}")
+                help_lines.append(f"    {desc}")
+            else:
+                help_lines.append(f"  /{cmd_id}")
 
-  /create <name> [--no-git]
-    Create a new folder (with git init by default)
-    Use --no-git for non-repo folders like knowledge vaults
+    help_lines.append("")
+    help_lines.append("Or just send a message to chat with the agent!")
 
-  /add <name> <path>
-    Add an existing folder to the workspace
-
-  /list
-    List all folders in the workspace
-
-  /remove <name>
-    Remove a folder from workspace (doesn't delete files)
-
-  /status
-    Show workspace status
-
-  /engine [name]
-    Show or set the default engine (claude, codex, etc.)
-
-  /help
-    Show this help message
-
-Worker Topic Commands:
-  /ralph <prompt> [--max-iterations N]
-    Run an iterative agent loop
-
-  /cancel
-    Cancel the current run or ralph loop
-
-Or just send a message to chat with the agent!
-"""
     await manager.send_to_topic(
         None,
-        help_text,
+        "\n".join(help_lines),
         reply_to_message_id=reply_to_message_id,
     )

--- a/src/pochi/workspace/commands.py
+++ b/src/pochi/workspace/commands.py
@@ -73,6 +73,10 @@ async def handle_slash_command(
     command = route.command
     args = route.command_args
 
+    # Guard for None command
+    if command is None:
+        return
+
     handlers = {
         "clone": _handle_clone,
         "create": _handle_create,

--- a/src/pochi/worktrees.py
+++ b/src/pochi/worktrees.py
@@ -1,0 +1,266 @@
+"""Git worktree management for isolated branch execution.
+
+This module provides worktree creation and management, enabling the @branch
+directive to run agent sessions in isolated git worktrees.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from .logging import get_logger
+from .utils.git import (
+    GitError,
+    add_worktree,
+    branch_exists,
+    get_default_branch,
+    is_git_repo,
+    list_worktrees,
+    remote_branch_exists,
+    worktree_exists,
+)
+
+logger = get_logger(__name__)
+
+# Default directory name for worktrees within a folder
+DEFAULT_WORKTREES_DIR = ".worktrees"
+
+# Pattern for valid branch names (git branch naming rules, simplified)
+# Allows alphanumeric, /, -, _, .
+BRANCH_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$")
+
+
+class WorktreeError(Exception):
+    """Error during worktree operation."""
+
+    pass
+
+
+def sanitize_branch_name(name: str) -> str:
+    """Sanitize a branch name for safe filesystem and git usage.
+
+    - Strips leading/trailing whitespace
+    - Replaces spaces with hyphens
+    - Removes invalid characters
+    - Collapses consecutive separators
+
+    Args:
+        name: Raw branch name from user input.
+
+    Returns:
+        Sanitized branch name.
+
+    Raises:
+        ValueError: If the resulting name is empty or invalid.
+    """
+    if not name:
+        raise ValueError("Branch name cannot be empty")
+
+    # Strip whitespace
+    name = name.strip()
+
+    # Replace spaces with hyphens
+    name = name.replace(" ", "-")
+
+    # Remove leading slashes (git doesn't like /foo)
+    name = name.lstrip("/")
+
+    # Remove .. sequences (security/git issue)
+    while ".." in name:
+        name = name.replace("..", ".")
+
+    # Collapse consecutive slashes
+    while "//" in name:
+        name = name.replace("//", "/")
+
+    # Collapse consecutive hyphens
+    while "--" in name:
+        name = name.replace("--", "-")
+
+    # Remove trailing slashes and dots
+    name = name.rstrip("/.")
+
+    # Final validation
+    if not name:
+        raise ValueError("Branch name cannot be empty after sanitization")
+
+    # Check for valid characters
+    if not BRANCH_NAME_RE.match(name):
+        raise ValueError(f"Invalid branch name: {name}")
+
+    return name
+
+
+def get_worktree_path(
+    folder_path: Path,
+    branch: str,
+    worktrees_dir: str = DEFAULT_WORKTREES_DIR,
+) -> Path:
+    """Get the path where a worktree for a branch should be located.
+
+    Args:
+        folder_path: Path to the main repository folder.
+        branch: Branch name.
+        worktrees_dir: Directory name for worktrees (relative to folder).
+
+    Returns:
+        Absolute path to the worktree directory.
+    """
+    # Convert branch slashes to double underscores for filesystem safety
+    # e.g., feature/foo -> feature__foo
+    safe_name = branch.replace("/", "__")
+    return folder_path / worktrees_dir / safe_name
+
+
+def ensure_worktree(
+    folder_path: Path,
+    branch: str,
+    *,
+    worktrees_dir: str = DEFAULT_WORKTREES_DIR,
+    base_branch: str | None = None,
+) -> Path:
+    """Ensure a worktree exists for the given branch, creating if needed.
+
+    Auto-creation logic:
+    1. If worktree exists → use it
+    2. If local branch exists → git worktree add <path> <branch>
+    3. If origin/<branch> exists → git worktree add -b <branch> <path> origin/<branch>
+    4. Otherwise → create new branch from base (default branch)
+
+    Args:
+        folder_path: Path to the main repository folder.
+        branch: Branch name to use/create.
+        worktrees_dir: Directory name for worktrees.
+        base_branch: Base branch for new branches (auto-detected if None).
+
+    Returns:
+        Path to the worktree directory.
+
+    Raises:
+        WorktreeError: If worktree creation fails.
+    """
+    if not is_git_repo(folder_path):
+        raise WorktreeError(f"Not a git repository: {folder_path}")
+
+    worktree_path = get_worktree_path(folder_path, branch, worktrees_dir)
+
+    # Case 1: Worktree already exists
+    if worktree_exists(worktree_path, folder_path):
+        logger.info(
+            "worktree.reused",
+            path=str(worktree_path),
+            branch=branch,
+        )
+        return worktree_path
+
+    # Create parent directory if needed
+    worktree_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        # Case 2: Local branch exists
+        if branch_exists(branch, folder_path):
+            logger.info(
+                "worktree.creating.local_branch",
+                branch=branch,
+                path=str(worktree_path),
+            )
+            add_worktree(worktree_path, branch, folder_path)
+            return worktree_path
+
+        # Case 3: Remote branch exists
+        if remote_branch_exists(branch, folder_path):
+            logger.info(
+                "worktree.creating.remote_branch",
+                branch=branch,
+                path=str(worktree_path),
+            )
+            add_worktree(
+                worktree_path,
+                branch,
+                folder_path,
+                create_branch=True,
+                base_ref=f"origin/{branch}",
+            )
+            return worktree_path
+
+        # Case 4: New branch from base
+        if base_branch is None:
+            base_branch = get_default_branch(folder_path)
+
+        logger.info(
+            "worktree.creating.new_branch",
+            branch=branch,
+            base=base_branch,
+            path=str(worktree_path),
+        )
+
+        # Determine base ref - prefer origin/base if it exists
+        if remote_branch_exists(base_branch, folder_path):
+            base_ref = f"origin/{base_branch}"
+        elif branch_exists(base_branch, folder_path):
+            base_ref = base_branch
+        else:
+            # Last resort: HEAD
+            base_ref = "HEAD"
+
+        add_worktree(
+            worktree_path,
+            branch,
+            folder_path,
+            create_branch=True,
+            base_ref=base_ref,
+        )
+        return worktree_path
+
+    except GitError as e:
+        raise WorktreeError(f"Failed to create worktree: {e}") from e
+
+
+def find_worktree_for_path(path: Path, repo_path: Path) -> str | None:
+    """Find which branch a worktree path corresponds to.
+
+    Args:
+        path: Path that might be a worktree.
+        repo_path: Main repository path.
+
+    Returns:
+        Branch name if path is a worktree, None otherwise.
+    """
+    worktrees = list_worktrees(repo_path)
+    path_str = str(path.resolve())
+
+    for wt in worktrees:
+        if wt.get("path") == path_str:
+            return wt.get("branch")
+
+    return None
+
+
+def get_active_worktrees(
+    folder_path: Path,
+    worktrees_dir: str = DEFAULT_WORKTREES_DIR,
+) -> list[tuple[str, Path]]:
+    """Get all active worktrees for a folder.
+
+    Args:
+        folder_path: Path to the main repository folder.
+        worktrees_dir: Directory name for worktrees.
+
+    Returns:
+        List of (branch_name, worktree_path) tuples.
+    """
+    worktrees_path = folder_path / worktrees_dir
+    if not worktrees_path.exists():
+        return []
+
+    result: list[tuple[str, Path]] = []
+    worktrees = list_worktrees(folder_path)
+
+    for wt in worktrees:
+        wt_path = wt.get("path", "")
+        branch = wt.get("branch", "")
+        if wt_path.startswith(str(worktrees_path)) and branch:
+            result.append((branch, Path(wt_path)))
+
+    return result

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,113 @@
+"""Tests for pochi.context module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pochi.context import RunContext, resolve_run_path
+
+
+class TestRunContext:
+    """Tests for RunContext dataclass."""
+
+    def test_format_footer_with_branch(self) -> None:
+        """Test format_footer with branch returns ctx: folder @ branch format."""
+        ctx = RunContext(folder="backend", branch="feature/auth")
+        assert ctx.format_footer() == "`ctx: backend @ feature/auth`"
+
+    def test_format_footer_without_branch(self) -> None:
+        """Test format_footer without branch returns ctx: folder format."""
+        ctx = RunContext(folder="backend")
+        assert ctx.format_footer() == "`ctx: backend`"
+
+    def test_parse_with_branch(self) -> None:
+        """Test parsing context with branch from message text."""
+        text = (
+            "Some response\n\n`ctx: backend @ feature/auth`\n`claude --resume abc123`"
+        )
+        ctx = RunContext.parse(text)
+
+        assert ctx is not None
+        assert ctx.folder == "backend"
+        assert ctx.branch == "feature/auth"
+
+    def test_parse_without_branch(self) -> None:
+        """Test parsing context without branch from message text."""
+        text = "Some response\n\n`ctx: backend`\n`claude --resume abc123`"
+        ctx = RunContext.parse(text)
+
+        assert ctx is not None
+        assert ctx.folder == "backend"
+        assert ctx.branch is None
+
+    def test_parse_no_context(self) -> None:
+        """Test parsing returns None when no context footer found."""
+        text = "Some response without context footer"
+        ctx = RunContext.parse(text)
+        assert ctx is None
+
+    def test_parse_empty_string(self) -> None:
+        """Test parsing empty string returns None."""
+        ctx = RunContext.parse("")
+        assert ctx is None
+
+    def test_parse_strips_whitespace(self) -> None:
+        """Test parsing strips whitespace from folder and branch."""
+        text = "`ctx:  backend  @  feature/foo  `"
+        ctx = RunContext.parse(text)
+
+        assert ctx is not None
+        assert ctx.folder == "backend"
+        assert ctx.branch == "feature/foo"
+
+    def test_parse_complex_branch_name(self) -> None:
+        """Test parsing complex branch name with slashes and hyphens."""
+        text = "`ctx: my-repo @ feature/user-auth_v2`"
+        ctx = RunContext.parse(text)
+
+        assert ctx is not None
+        assert ctx.folder == "my-repo"
+        assert ctx.branch == "feature/user-auth_v2"
+
+    def test_frozen_dataclass(self) -> None:
+        """Test that RunContext is immutable."""
+        ctx = RunContext(folder="backend", branch="main")
+        with pytest.raises(AttributeError):
+            ctx.folder = "frontend"  # type: ignore
+
+
+class TestResolveRunPath:
+    """Tests for resolve_run_path function."""
+
+    def test_without_branch(self, tmp_path: Path) -> None:
+        """Test resolve_run_path returns folder path when no branch."""
+        result = resolve_run_path(tmp_path, "backend", None)
+        assert result == tmp_path / "backend"
+
+    def test_with_simple_branch(self, tmp_path: Path) -> None:
+        """Test resolve_run_path with simple branch name."""
+        result = resolve_run_path(tmp_path, "backend", "feature-foo")
+        expected = tmp_path / "backend" / ".worktrees" / "feature-foo"
+        assert result == expected
+
+    def test_with_slash_branch(self, tmp_path: Path) -> None:
+        """Test resolve_run_path converts branch slashes to double underscores."""
+        result = resolve_run_path(tmp_path, "backend", "feature/foo")
+        expected = tmp_path / "backend" / ".worktrees" / "feature__foo"
+        assert result == expected
+
+    def test_custom_worktrees_dir(self, tmp_path: Path) -> None:
+        """Test resolve_run_path with custom worktrees directory."""
+        result = resolve_run_path(
+            tmp_path, "backend", "feature-foo", worktrees_dir=".wt"
+        )
+        expected = tmp_path / "backend" / ".wt" / "feature-foo"
+        assert result == expected
+
+    def test_nested_folder_path(self, tmp_path: Path) -> None:
+        """Test resolve_run_path with nested folder path."""
+        result = resolve_run_path(tmp_path, "repos/backend", "main")
+        expected = tmp_path / "repos/backend" / ".worktrees" / "main"
+        assert result == expected

--- a/tests/test_worktrees.py
+++ b/tests/test_worktrees.py
@@ -1,0 +1,283 @@
+"""Tests for pochi.worktrees module."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from pochi.worktrees import (
+    DEFAULT_WORKTREES_DIR,
+    WorktreeError,
+    ensure_worktree,
+    get_active_worktrees,
+    get_worktree_path,
+    sanitize_branch_name,
+)
+
+
+class TestSanitizeBranchName:
+    """Tests for sanitize_branch_name function."""
+
+    def test_simple_name_unchanged(self) -> None:
+        """Test that a simple valid name is unchanged."""
+        assert sanitize_branch_name("feature-foo") == "feature-foo"
+
+    def test_name_with_slash(self) -> None:
+        """Test that names with slashes are preserved."""
+        assert sanitize_branch_name("feature/new-thing") == "feature/new-thing"
+
+    def test_strips_whitespace(self) -> None:
+        """Test that leading/trailing whitespace is stripped."""
+        assert sanitize_branch_name("  branch-name  ") == "branch-name"
+
+    def test_replaces_spaces_with_hyphens(self) -> None:
+        """Test that spaces are replaced with hyphens."""
+        assert sanitize_branch_name("my new branch") == "my-new-branch"
+
+    def test_removes_leading_slashes(self) -> None:
+        """Test that leading slashes are removed."""
+        assert sanitize_branch_name("/feature/foo") == "feature/foo"
+
+    def test_removes_double_dots(self) -> None:
+        """Test that .. sequences are collapsed."""
+        assert sanitize_branch_name("foo..bar") == "foo.bar"
+
+    def test_collapses_double_slashes(self) -> None:
+        """Test that // sequences are collapsed."""
+        assert sanitize_branch_name("foo//bar") == "foo/bar"
+
+    def test_collapses_double_hyphens(self) -> None:
+        """Test that -- sequences are collapsed."""
+        assert sanitize_branch_name("foo--bar") == "foo-bar"
+
+    def test_removes_trailing_slash(self) -> None:
+        """Test that trailing slashes are removed."""
+        assert sanitize_branch_name("feature/foo/") == "feature/foo"
+
+    def test_removes_trailing_dot(self) -> None:
+        """Test that trailing dots are removed."""
+        assert sanitize_branch_name("feature.") == "feature"
+
+    def test_empty_string_raises(self) -> None:
+        """Test that empty string raises ValueError."""
+        with pytest.raises(ValueError, match="cannot be empty"):
+            sanitize_branch_name("")
+
+    def test_whitespace_only_raises(self) -> None:
+        """Test that whitespace-only string raises ValueError."""
+        with pytest.raises(ValueError, match="cannot be empty"):
+            sanitize_branch_name("   ")
+
+    def test_invalid_characters_raise(self) -> None:
+        """Test that invalid characters raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid branch name"):
+            sanitize_branch_name("foo$bar")
+
+    def test_name_with_underscore(self) -> None:
+        """Test that underscores are allowed."""
+        assert sanitize_branch_name("feature_foo") == "feature_foo"
+
+    def test_complex_name(self) -> None:
+        """Test a complex but valid branch name."""
+        assert (
+            sanitize_branch_name("feature/foo-bar_123.test")
+            == "feature/foo-bar_123.test"
+        )
+
+
+class TestGetWorktreePath:
+    """Tests for get_worktree_path function."""
+
+    def test_simple_branch(self, tmp_path: Path) -> None:
+        """Test path for simple branch name."""
+        result = get_worktree_path(tmp_path, "feature-foo")
+        expected = tmp_path / DEFAULT_WORKTREES_DIR / "feature-foo"
+        assert result == expected
+
+    def test_branch_with_slash(self, tmp_path: Path) -> None:
+        """Test path for branch with slash (converted to double underscore)."""
+        result = get_worktree_path(tmp_path, "feature/foo")
+        expected = tmp_path / DEFAULT_WORKTREES_DIR / "feature__foo"
+        assert result == expected
+
+    def test_custom_worktrees_dir(self, tmp_path: Path) -> None:
+        """Test path with custom worktrees directory."""
+        result = get_worktree_path(tmp_path, "feature-foo", worktrees_dir=".wt")
+        expected = tmp_path / ".wt" / "feature-foo"
+        assert result == expected
+
+    def test_nested_slash_branch(self, tmp_path: Path) -> None:
+        """Test path for branch with multiple slashes."""
+        result = get_worktree_path(tmp_path, "feature/user/auth")
+        expected = tmp_path / DEFAULT_WORKTREES_DIR / "feature__user__auth"
+        assert result == expected
+
+
+class TestEnsureWorktree:
+    """Tests for ensure_worktree function."""
+
+    @pytest.fixture
+    def git_repo(self, tmp_path: Path) -> Path:
+        """Create a minimal git repository for testing."""
+        repo_path = tmp_path / "test-repo"
+        repo_path.mkdir()
+
+        # Initialize git repo
+        subprocess.run(
+            ["git", "init"],
+            cwd=repo_path,
+            capture_output=True,
+            check=True,
+        )
+
+        # Configure git user
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=repo_path,
+            check=True,
+        )
+
+        # Create initial commit
+        (repo_path / "README.md").write_text("# Test\n")
+        subprocess.run(["git", "add", "."], cwd=repo_path, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Initial commit"],
+            cwd=repo_path,
+            check=True,
+        )
+
+        return repo_path
+
+    def test_raises_if_not_git_repo(self, tmp_path: Path) -> None:
+        """Test that non-git directory raises WorktreeError."""
+        non_repo = tmp_path / "not-a-repo"
+        non_repo.mkdir()
+
+        with pytest.raises(WorktreeError, match="Not a git repository"):
+            ensure_worktree(non_repo, "feature-foo")
+
+    def test_creates_new_branch_worktree(self, git_repo: Path) -> None:
+        """Test creating worktree for new branch."""
+        result = ensure_worktree(git_repo, "feature-new")
+
+        assert result.exists()
+        assert result == git_repo / DEFAULT_WORKTREES_DIR / "feature-new"
+        assert (result / "README.md").exists()
+
+    def test_reuses_existing_worktree(self, git_repo: Path) -> None:
+        """Test that existing worktree is reused."""
+        # Create worktree first time
+        result1 = ensure_worktree(git_repo, "feature-reuse")
+        assert result1.exists()
+
+        # Create file in worktree
+        marker = result1 / "marker.txt"
+        marker.write_text("test")
+
+        # Second call should reuse
+        result2 = ensure_worktree(git_repo, "feature-reuse")
+        assert result2 == result1
+        assert marker.exists()
+
+    def test_creates_worktree_for_existing_branch(self, git_repo: Path) -> None:
+        """Test creating worktree for existing local branch."""
+        # Create branch first
+        subprocess.run(
+            ["git", "branch", "existing-branch"],
+            cwd=git_repo,
+            check=True,
+        )
+
+        result = ensure_worktree(git_repo, "existing-branch")
+        assert result.exists()
+        assert (result / "README.md").exists()
+
+    def test_creates_parent_directories(self, git_repo: Path) -> None:
+        """Test that parent worktrees directory is created."""
+        worktrees_dir = git_repo / DEFAULT_WORKTREES_DIR
+        assert not worktrees_dir.exists()
+
+        ensure_worktree(git_repo, "feature-test")
+        assert worktrees_dir.exists()
+
+    def test_custom_worktrees_dir(self, git_repo: Path) -> None:
+        """Test using custom worktrees directory."""
+        result = ensure_worktree(git_repo, "feature-custom", worktrees_dir=".custom")
+
+        expected = git_repo / ".custom" / "feature-custom"
+        assert result == expected
+        assert result.exists()
+
+
+class TestGetActiveWorktrees:
+    """Tests for get_active_worktrees function."""
+
+    @pytest.fixture
+    def git_repo_with_worktrees(self, tmp_path: Path) -> Path:
+        """Create a git repo with some worktrees."""
+        repo_path = tmp_path / "test-repo"
+        repo_path.mkdir()
+
+        # Initialize git repo
+        subprocess.run(["git", "init"], cwd=repo_path, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=repo_path,
+            check=True,
+        )
+        (repo_path / "README.md").write_text("# Test\n")
+        subprocess.run(["git", "add", "."], cwd=repo_path, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Initial commit"], cwd=repo_path, check=True
+        )
+
+        # Create worktrees
+        ensure_worktree(repo_path, "feature-one")
+        ensure_worktree(repo_path, "feature-two")
+
+        return repo_path
+
+    def test_returns_empty_for_no_worktrees(self, tmp_path: Path) -> None:
+        """Test returns empty list when no worktrees exist."""
+        repo_path = tmp_path / "empty-repo"
+        repo_path.mkdir()
+        subprocess.run(["git", "init"], cwd=repo_path, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=repo_path,
+            check=True,
+        )
+        (repo_path / "README.md").write_text("# Test\n")
+        subprocess.run(["git", "add", "."], cwd=repo_path, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Initial commit"], cwd=repo_path, check=True
+        )
+
+        result = get_active_worktrees(repo_path)
+        assert result == []
+
+    def test_returns_active_worktrees(self, git_repo_with_worktrees: Path) -> None:
+        """Test returns list of active worktrees."""
+        result = get_active_worktrees(git_repo_with_worktrees)
+
+        assert len(result) == 2
+        branches = [branch for branch, _ in result]
+        assert "feature-one" in branches
+        assert "feature-two" in branches


### PR DESCRIPTION
## Summary
- Implement entrypoint-based plugin architecture inspired by takopi v0.11.0
- Add engine, transport, and command plugin support with lazy discovery
- Create public API module for plugin authors (`pochi.api`)
- Add `pochi plugins` CLI command for plugin inspection

## Test plan
- [x] All 615 tests pass
- [x] `pochi plugins` lists discovered plugins without loading
- [x] `pochi plugins --load` validates all plugins successfully
- [x] Public API imports work: `from pochi.api import EngineBackend, ...`
- [x] Ruff linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)